### PR TITLE
bugfix: added try/except for impossible tautomer searches

### DIFF
--- a/compechem/modules/crest.py
+++ b/compechem/modules/crest.py
@@ -36,7 +36,14 @@ def tautomer_search(mol, nproc=1, remove_tdir=True, optionals=""):
         f"crest geom.xyz --alpb water --chrg {mol.charge} --uhf {mol.spin-1} --mquick --fstrict --tautomerize {optionals} -T {nproc} > output.out 2>> output.err"
     )
 
-    tools.cyclization_check(mol, "geom.xyz", "tautomers.xyz")
+    try:
+        tools.cyclization_check(mol, "geom.xyz", "tautomers.xyz")
+    except:
+        print(f"ERROR: no tautomers possible for molecule {mol.name}. Ignoring tautomer search.")
+        tools.process_output(
+            mol, "CREST", mol.charge, mol.spin, "tautomers", tdir, remove_tdir, parent_dir
+        )
+        return [mol]
 
     tautomers = tools.split_multixyz(mol, file="tautomers.xyz", suffix="t")
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "GES-comp-echem" %}
-{% set version = "0.1.11a" %}
+{% set version = "0.1.12a" %}
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name="GES-comp-echem",
-    version="0.1.11a",
+    version="0.1.12a",
     description="",
     long_description="",
     packages=["compechem"],


### PR DESCRIPTION
If a tautomer search is not possible (no suitable pi orbitals found in the molecule) print an error code and return a list only containing the original molecule.