### PR TITLE
Spin density render

### DIFF
--- a/compechem/tools/__init__.py
+++ b/compechem/tools/__init__.py
@@ -11,3 +11,7 @@ from compechem.tools.externalutilities import compress_dftb_trajectory
 from compechem.tools.xyz2mol import maxdist
 
 from compechem.tools.reorderenergies import reorder_energies
+
+from compechem.tools.vmdtools import render_fukui_cube
+from compechem.tools.vmdtools import render_condensed_fukui
+from compechem.tools.vmdtools import render_spin_density_cube

--- a/compechem/tools/vmdtools.py
+++ b/compechem/tools/vmdtools.py
@@ -61,11 +61,13 @@ def render_fukui_cube(
             mol representation CPK 1.000000 0.300000 150.000000 12.000000
             mol selection all
             mol material Opaque
+
             mol addrep 0
             mol modcolor 1 0 Volume 0
             mol modstyle 1 0 Isosurface {isovalue} 0 0 0 1 1
             mol modmaterial 1 0 Translucent
             mol scaleminmax 0 1 0.000000 1.000000
+            
             display cuemode Linear
             """
         )
@@ -76,7 +78,7 @@ def render_fukui_cube(
                 mol addrep 0
                 mol modcolor 2 0 Volume 0
                 mol modstyle 2 0 Isosurface {-isovalue} 0 0 0 1 1
-                mol modmaterial 1 0 Translucent
+                mol modmaterial 2 0 Translucent
                 mol scaleminmax 0 2 -1.000000 0.000000
                 """
             )
@@ -188,6 +190,93 @@ def render_condensed_fukui(
         vmd_script.write(
             f"""
             render Tachyon {root_name}_condensed.dat "{tachyon_path}" -fullshade -aasamples 12 %s -format BMP -res {resolution} {resolution} -o {root_name}_condensed.bmp
+            exit
+            """
+        )
+
+        vmd_script.seek(0)
+        system(f"vmd -dispdev text -e {vmd_script.name}")
+
+
+def render_spin_density_cube(
+    cubfile: str,
+    isovalue: float = 0.005,
+    resolution: int = 4800,
+    shadows: bool = True,
+    ambientocclusion: bool = True,
+    dof: bool = True,
+    VMD_PATH: str = None,
+) -> None:
+    """
+    Given the path to a spin density cube file saves a `.bmp` render the function.
+
+    Arguments
+    ---------
+    cubefile: str
+        The path to the `.fukui.cube` file that must be rendered.
+    isovalue: float
+        The isovalue at which the contour must be plotted (default: 0.003).
+    resolution: int
+        The resolution of the output image (default: 4800).
+    shadows: bool
+        If set to True will enable the vmd shadows option
+    ambientocclusion: bool
+        If set to True will enable the vmd ambientocclusion option
+    dof: bool
+        If set to True will enable the vmd dof option
+    VMD_PATH: str
+        The path to the vmd folder. Is set to None (default), will automatically search vmd
+        in the system PATH.
+    """
+    vmd_root = VMD_PATH if VMD_PATH is not None else locate_vmd()
+    tachyon_path = join(vmd_root, "lib/vmd/tachyon_LINUXAMD64")
+
+    root_name = basename(cubfile).strip(".fukui.cube")
+
+    with tmp(mode="w+") as vmd_script:
+
+        vmd_script.write(
+            f"""
+            mol addrep 0
+            display projection Orthographic
+            display resetview
+            mol new {cubfile} type {{cube}} first 0 last -1 step 1 waitfor 1 volsets {{0 }}
+            animate style Loop
+            axes location Off
+            mol modstyle 0 0 CPK 1.000000 0.300000 12.000000 12.000000
+            mol color Name
+            mol representation CPK 1.000000 0.300000 150.000000 12.000000
+            mol selection all
+            mol material Opaque
+            mol addrep 0
+            mol modcolor 1 0 ColorID 31
+            mol modstyle 1 0 Isosurface {isovalue} 0 0 0 1 1
+            mol modmaterial 1 0 Translucent
+            mol scaleminmax 0 1 0.000000 1.000000
+            mol addrep 0
+            mol modcolor 2 0 ColorID 26
+            mol modstyle 2 0 Isosurface {-isovalue} 0 0 0 1 1
+            mol modmaterial 2 0 Translucent
+            mol scaleminmax 0 2 -1.000000 0.000000
+            display cuemode Linear
+            """
+        )
+
+        if shadows:
+            vmd_script.write("display shadows on\n")
+
+        if ambientocclusion:
+            vmd_script.write("display ambientocclusion on\n")
+
+        if dof:
+            vmd_script.write("display dof on")
+
+        vmd_script.write(
+            f"""
+            color Display Background white
+            color Element C black
+            mol modcolor 0 0 Element
+            render Tachyon {root_name}.dat "{tachyon_path}" -fullshade -aasamples 12 %s -format BMP -res {resolution} {resolution} -o {root_name}.bmp
             exit
             """
         )

--- a/compechem/tools/vmdtools.py
+++ b/compechem/tools/vmdtools.py
@@ -63,7 +63,7 @@ def render_fukui_cube(
             mol material Opaque
 
             mol addrep 0
-            mol modcolor 1 0 Volume 0
+            mol modcolor 1 0 ColorID 1
             mol modstyle 1 0 Isosurface {isovalue} 0 0 0 1 1
             mol modmaterial 1 0 Translucent
             mol scaleminmax 0 1 0.000000 1.000000
@@ -76,7 +76,7 @@ def render_fukui_cube(
             vmd_script.write(
                 f"""
                 mol addrep 0
-                mol modcolor 2 0 Volume 0
+                mol modcolor 2 0 ColorID 0
                 mol modstyle 2 0 Isosurface {-isovalue} 0 0 0 1 1
                 mol modmaterial 2 0 Translucent
                 mol scaleminmax 0 2 -1.000000 0.000000
@@ -158,6 +158,7 @@ def render_condensed_fukui(
             mol material Opaque
             mol modrep 0 0
             color Display Background white
+            color scale method BWR
             display cuemode Linear
             axes location Off
 

--- a/compechem/tools/xyz2mol.py
+++ b/compechem/tools/xyz2mol.py
@@ -740,9 +740,10 @@ def xyz2mol(atoms, coordinates, charge=0, allow_charged_fragments=True,
 
     return new_mols
 
+from compechem.systems import System
 
 def maxdist(
-    inputmol, 
+    inputmol: System, 
     charge=None, 
     output_format=None, 
     no_charged_fragments=True, 
@@ -758,7 +759,7 @@ def maxdist(
 
     with sh.pushd(tdir):
 
-        inputmol.write_xyz(f"{inputmol.name}.xyz")
+        inputmol.geometry.write_xyz(f"{inputmol.name}.xyz")
 
         # read xyz file
         filename = f"{inputmol.name}.xyz"

--- a/docs/API/tools.md
+++ b/docs/API/tools.md
@@ -78,3 +78,10 @@
 ```{eval-rst}
 .. autofunction:: compechem.tools.reorder_energies
 ```
+
+## The `compechem.tools.vmdtools` sub-module 
+
+```{eval-rst}
+.. automodule:: compechem.tools.vmdtools
+    :members:
+```

--- a/docs/Guide/tools.md
+++ b/docs/Guide/tools.md
@@ -66,3 +66,17 @@ Reorders a `System` list at a specific level of theory, provided the following a
 * `method_vib` (any Input type from a `wrapper`): level of theory for the vibronic component of the total energy. By default GFN2-xTB
 
 and returns the same list, but with a new ordering, given by the total energies recalculated at the new level of theory.
+
+## VMD based tools
+
+The `copechem.tools` module also provides a `vmdtools` submodule containing simple VMD-based functions to render graphical representations of molecular properties such as:
+
+* Volumetric and condensed Fukui functions
+* Spin densities
+
+The following conventions have been adopted in the representation:
+
+* Positive/high values of functions/densities related to the electronic density are represented in red while negative/low values are represented in blue.
+* Positive/high values of functions/densities related to the spin density are represented in orange while negative/low values are represented in violet.
+
+Please refer to the API for details about the call to the various render functions.


### PR DESCRIPTION
1. Added spin density render function based on VMD
2. Defined a convention in the coloring of rendered quantities for both Fukui functions and spin densities 
    -  Fixed coloring of isosurface using ColorID
    -  Set BWR colormap for condensed Fukui functions
3. Fast update of the documentation to mention VMD-based tools + added API entry
4. Bugfix in Fukui function render style
5. Included bugfix from @GES-lbabetto in the `xyz2mol.py`

When merged closes #75 