### PR TITLE
Bugfixes

### DIFF
--- a/compechem/engines/dftbplus.py
+++ b/compechem/engines/dftbplus.py
@@ -5,10 +5,14 @@ from tempfile import mkdtemp
 from compechem.config import get_ncores
 from compechem.core.base import Engine
 from compechem.systems import System, Ensemble
-from compechem.tools import process_output
-from compechem.tools import save_dftb_trajectory
-from compechem.tools import compress_dftb_trajectory
-from compechem.tools import split_multixyz
+from compechem.tools import (
+    process_output,
+    save_dftb_trajectory,
+    compress_dftb_trajectory,
+    split_multixyz,
+)
+from compechem.tools.internaltools import clean_suffix
+
 from typing import Dict
 from compechem.core.dependency_finder import locate_dftbplus, locate_dftbparamdir
 
@@ -103,6 +107,7 @@ class DFTBInput(Engine):
         self.__output_suffix = "DFTB"
         self.__output_suffix += "3" if thirdorder else ""
         self.__output_suffix += "-D3" if dispersion else ""
+        self.__output_suffix = clean_suffix(self.__output_suffix)
 
         self.atom_dict = {
             "Br": "d",
@@ -344,7 +349,7 @@ class DFTBInput(Engine):
 
         tdir = mkdtemp(
             prefix=mol.name + "_",
-            suffix=f"_{self.method.split()[0]}_spe",
+            suffix=f"_{self.__output_suffix}_spe",
             dir=os.getcwd(),
         )
 
@@ -442,7 +447,7 @@ class DFTBInput(Engine):
 
         tdir = mkdtemp(
             prefix=mol.name + "_",
-            suffix=f"_{self.method.split()[0]}_opt",
+            suffix=f"_{self.__output_suffix}_opt",
             dir=os.getcwd(),
         )
 
@@ -562,7 +567,7 @@ class DFTBInput(Engine):
 
         tdir = mkdtemp(
             prefix=mol.name + "_",
-            suffix=f"_{self.method.split()[0]}_md_nvt",
+            suffix=f"_{self.__output_suffix}_md_nvt",
             dir=os.getcwd(),
         )
 
@@ -700,7 +705,7 @@ class DFTBInput(Engine):
 
         tdir = mkdtemp(
             prefix=mol.name + "_",
-            suffix=f"_{self.method.split()[0]}_anneal",
+            suffix=f"_{self.__output_suffix}_anneal",
             dir=os.getcwd(),
         )
 

--- a/compechem/engines/orca.py
+++ b/compechem/engines/orca.py
@@ -216,7 +216,7 @@ class OrcaInput(Engine):
             os.system(f"{self.__ORCADIR}/orca input.inp > output.out {self.__MPI_FLAGS}")
 
             if inplace is False:
-                newmol = System(f"{mol.name}.xyz", charge, spin)
+                newmol = System(f"{mol.name}.xyz", charge=charge, spin=spin)
                 newmol.properties = copy.copy(mol.properties)
                 self.parse_output(newmol)
 
@@ -407,7 +407,7 @@ class OrcaInput(Engine):
             os.system(f"{self.__ORCADIR}/orca input.inp > output.out {self.__MPI_FLAGS}")
 
             if inplace is False:
-                newmol = System(f"{mol.name}.xyz", charge, spin)
+                newmol = System(f"{mol.name}.xyz", charge=charge, spin=spin)
                 newmol.properties = copy.copy(mol.properties)
                 self.parse_output(newmol)
 
@@ -493,7 +493,7 @@ class OrcaInput(Engine):
             os.system(f"{self.__ORCADIR}/orca input.inp > output.out {self.__MPI_FLAGS}")
 
             if inplace is False:
-                newmol = System(f"{mol.name}.xyz", charge, spin)
+                newmol = System(f"{mol.name}.xyz", charge=charge, spin=spin)
                 newmol.properties = copy.copy(mol.properties)
                 self.parse_output(newmol)
 

--- a/compechem/engines/orca.py
+++ b/compechem/engines/orca.py
@@ -682,8 +682,8 @@ class OrcaInput(Engine):
                 # proceed with the file parsing else continue
                 if counter == sections:
 
-                    # Check if the section contains also the "SPIN POPULATIONS" column
-                    if "SPIN POPULATIONS" in line:
+                    # Check if the section contains also the "SPIN" column (either "SPIN POPULATIONS" or "SPIN DENSITIES")
+                    if "SPIN" in line:
                         spin_available = True
 
                     _ = file.readline()  # Skip the table line

--- a/compechem/engines/orca.py
+++ b/compechem/engines/orca.py
@@ -7,6 +7,7 @@ from compechem.systems import Ensemble, System
 from compechem.tools import process_output
 from compechem.core.base import Engine
 from compechem.core.dependency_finder import locate_orca
+from compechem.tools.internaltools import clean_suffix
 
 import logging
 
@@ -49,17 +50,18 @@ class OrcaInput(Engine):
         super().__init__(method)
 
         self.basis_set = basis_set if basis_set else ""
-        self.aux_basis = aux_basis
+        self.aux_basis = aux_basis if aux_basis else ""
         self.solvent = solvent
         self.optionals = optionals
         self.__MPI_FLAGS = MPI_FLAGS
         self.__ORCADIR = ORCADIR if ORCADIR else locate_orca(get_folder=True)
 
-        self.level_of_theory += f" | basis: {basis_set} | solvent: {solvent}"
+        self.level_of_theory += f""" | basis: {basis_set} | solvent: {solvent}"""
 
         self.__output_suffix = f"orca_{method}"
         self.__output_suffix += f"_{basis_set}" if basis_set else ""
         self.__output_suffix += f"_{solvent}" if solvent else "_vacuum"
+        self.__output_suffix = clean_suffix(self.__output_suffix)
 
     def write_input(
         self,
@@ -193,7 +195,7 @@ class OrcaInput(Engine):
 
         tdir = mkdtemp(
             prefix=mol.name + "_",
-            suffix=f"_{self.method.split()[0]}_spe",
+            suffix=f"_{self.__output_suffix}_spe",
             dir=os.getcwd(),
         )
 
@@ -292,7 +294,7 @@ class OrcaInput(Engine):
 
         tdir = mkdtemp(
             prefix=mol.name + "_",
-            suffix=f"_{self.method.split()[0]}_opt",
+            suffix=f"_{self.__output_suffix}_opt",
             dir=os.getcwd(),
         )
 
@@ -384,7 +386,7 @@ class OrcaInput(Engine):
 
         tdir = mkdtemp(
             prefix=mol.name + "_",
-            suffix=f"_{self.method.split()[0]}_freq",
+            suffix=f"_{self.__output_suffix}_freq",
             dir=os.getcwd(),
         )
 
@@ -471,7 +473,7 @@ class OrcaInput(Engine):
 
         tdir = mkdtemp(
             prefix=mol.name + "_",
-            suffix=f"_{self.method.split()[0]}_nfreq",
+            suffix=f"_{self.__output_suffix}_nfreq",
             dir=os.getcwd(),
         )
 
@@ -561,7 +563,7 @@ class OrcaInput(Engine):
 
         tdir = mkdtemp(
             prefix=mol.name + "_",
-            suffix=f"_{self.method.split()[0]}_scan",
+            suffix=f"_{self.__output_suffix}_scan",
             dir=os.getcwd(),
         )
 

--- a/compechem/engines/xtb.py
+++ b/compechem/engines/xtb.py
@@ -155,7 +155,7 @@ class XtbInput(Engine):
 
             if inplace is False:
 
-                newmol = System(f"{mol.name}.xyz", charge, spin)
+                newmol = System(f"{mol.name}.xyz", charge=charge, spin=spin)
                 newmol.properties = copy.copy(mol.properties)
                 self.parse_output(newmol)
 
@@ -276,7 +276,7 @@ class XtbInput(Engine):
             
                 if inplace is False:
 
-                    newmol = System(f"{mol.name}.xyz", charge, spin)
+                    newmol = System(f"{mol.name}.xyz", charge=charge, spin=spin)
                     newmol.geometry.load_xyz("xtbopt.xyz")
                     newmol.geometry.level_of_theory_geometry = self.level_of_theory
 
@@ -383,7 +383,7 @@ class XtbInput(Engine):
 
             if inplace is False:
 
-                newmol = System(f"{mol.name}.xyz", charge, spin)
+                newmol = System(f"{mol.name}.xyz", charge=charge, spin=spin)
 
                 newmol.properties = copy.copy(mol.properties)
 

--- a/compechem/engines/xtb.py
+++ b/compechem/engines/xtb.py
@@ -4,10 +4,8 @@ from tempfile import mkdtemp
 from compechem.config import get_ncores
 from compechem.core.base import Engine
 from compechem.systems import System
-from compechem.tools import process_output
-from compechem.tools import add_flag
-from compechem.tools import dissociation_check
-from compechem.tools import cyclization_check
+from compechem.tools import process_output, add_flag, dissociation_check, cyclization_check
+from compechem.tools.internaltools import clean_suffix
 from compechem.core.dependency_finder import locate_xtb
 
 import logging
@@ -48,6 +46,7 @@ class XtbInput(Engine):
         self.level_of_theory += f" | solvent: {solvent}"
         self.__output_suffix = f"xtb_{self.method}_"
         self.__output_suffix += "vacuum" if solvent is None else f"{self.solvent}"
+        self.__output_suffix = clean_suffix(self.__output_suffix)
 
     def write_input(
         self,
@@ -126,7 +125,7 @@ class XtbInput(Engine):
 
         tdir = mkdtemp(
             prefix=mol.name + "_",
-            suffix=f"_{self.method.split()[0]}_spe",
+            suffix=f"_{self.__output_suffix}_spe",
             dir=os.getcwd(),
         )
 
@@ -231,7 +230,7 @@ class XtbInput(Engine):
 
         tdir = mkdtemp(
             prefix=mol.name + "_",
-            suffix=f"_{self.method.split()[0]}_opt",
+            suffix=f"_{self.__output_suffix}_opt",
             dir=os.getcwd(),
         )
 
@@ -273,7 +272,7 @@ class XtbInput(Engine):
                 )
                 return None
             else:
-            
+
                 if inplace is False:
 
                     newmol = System(f"{mol.name}.xyz", charge=charge, spin=spin)
@@ -354,7 +353,7 @@ class XtbInput(Engine):
 
         tdir = mkdtemp(
             prefix=mol.name + "_",
-            suffix=f"_{self.method.split()[0]}_freq",
+            suffix=f"_{self.__output_suffix}_freq",
             dir=os.getcwd(),
         )
 
@@ -395,7 +394,7 @@ class XtbInput(Engine):
             process_output(
                 mol, self.__output_suffix, "freq", charge, spin, save_cubes=save_cubes
             )
-            
+
             if remove_tdir:
                 shutil.rmtree(tdir)
 
@@ -472,7 +471,7 @@ class XtbInput(Engine):
         if mulliken_charges != []:
             mol.properties.set_mulliken_charges(mulliken_charges, self)
             mol.properties.set_mulliken_spin_populations(mulliken_spins, self)
-    
+
     @property
     def output_suffix(self) -> str:
         """

--- a/compechem/tools/internaltools.py
+++ b/compechem/tools/internaltools.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import pickle
 from rdkit import Chem
+from copy import deepcopy
 from compechem.systems import System
 import logging
 
@@ -197,3 +198,13 @@ def save_dftb_trajectory(output_prefix):
 
     shutil.move("md.out", f"../MD_data/{output_prefix}_md.out")
     shutil.move("geo_end.xyz", f"../MD_data/{output_prefix}_geo_end.xyz")
+
+
+def clean_suffix(source: str) -> str:
+
+    string = deepcopy(source)
+
+    for char in ["\\", "/", ",", "*", "(", ")", "[", "]"]:
+        string = string.replace(char, "-")
+
+    return string

--- a/compechem/tools/vmdtools.py
+++ b/compechem/tools/vmdtools.py
@@ -44,7 +44,7 @@ def render_fukui_cube(
     vmd_root = VMD_PATH if VMD_PATH is not None else locate_vmd()
     tachyon_path = join(vmd_root, "lib/vmd/tachyon_LINUXAMD64")
 
-    root_name = basename(cubfile).strip(".fukui.cube")
+    root_name = basename(cubfile).rstrip(".fukui.cube")
 
     with tmp(mode="w+") as vmd_script:
 

--- a/compechem/tools/vmdtools.py
+++ b/compechem/tools/vmdtools.py
@@ -137,7 +137,7 @@ def render_condensed_fukui(
     vmd_root = VMD_PATH if VMD_PATH is not None else locate_vmd()
     tachyon_path = join(vmd_root, "lib/vmd/tachyon_LINUXAMD64")
 
-    root_name = basename(cubfile).strip(".fukui.cube")
+    root_name = basename(cubfile).rstrip(".fukui.cube")
 
     with tmp(mode="w+") as vmd_script:
 
@@ -232,7 +232,7 @@ def render_spin_density_cube(
     vmd_root = VMD_PATH if VMD_PATH is not None else locate_vmd()
     tachyon_path = join(vmd_root, "lib/vmd/tachyon_LINUXAMD64")
 
-    root_name = basename(cubfile).strip(".fukui.cube")
+    root_name = basename(cubfile).rstrip(".fukui.cube")
 
     with tmp(mode="w+") as vmd_script:
 

--- a/tests/integration/utils/orca_examples/water_spe_CCSD.inp
+++ b/tests/integration/utils/orca_examples/water_spe_CCSD.inp
@@ -1,0 +1,10 @@
+%pal
+  nprocs 4
+end
+
+%maxcore 350
+
+! DLPNO-CCSD def2-SVP
+! RIJCOSX AutoAux
+
+* xyzfile 1 2 water.xyz

--- a/tests/integration/utils/orca_examples/water_spe_CCSD.out
+++ b/tests/integration/utils/orca_examples/water_spe_CCSD.out
@@ -1,0 +1,1942 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+                                            #,                                       
+                                            ###                                      
+                                            ####                                     
+                                            #####                                    
+                                            ######                                   
+                                           ########,                                 
+                                     ,,################,,,,,                         
+                               ,,#################################,,                 
+                          ,,##########################################,,             
+                       ,#########################################, ''#####,          
+                    ,#############################################,,   '####,        
+                  ,##################################################,,,,####,       
+                ,###########''''           ''''###############################       
+              ,#####''   ,,,,##########,,,,          '''####'''          '####       
+            ,##' ,,,,###########################,,,                        '##       
+           ' ,,###''''                  '''############,,,                           
+         ,,##''                                '''############,,,,        ,,,,,,###''
+      ,#''                                            '''#######################'''  
+     '                                                          ''''####''''         
+             ,#######,   #######,   ,#######,      ##                                
+            ,#'     '#,  ##    ##  ,#'     '#,    #''#        ######   ,####,        
+            ##       ##  ##   ,#'  ##            #'  '#       #        #'  '#        
+            ##       ##  #######   ##           ,######,      #####,   #    #        
+            '#,     ,#'  ##    ##  '#,     ,#' ,#      #,         ##   #,  ,#        
+             '#######'   ##     ##  '#######'  #'      '#     #####' # '####'        
+
+
+
+                  #######################################################
+                  #                        -***-                        #
+                  #          Department of theory and spectroscopy      #
+                  #    Directorship and core code : Frank Neese         #
+                  #        Max Planck Institute fuer Kohlenforschung    #
+                  #                Kaiser Wilhelm Platz 1               #
+                  #                 D-45470 Muelheim/Ruhr               #
+                  #                      Germany                        #
+                  #                                                     #
+                  #                  All rights reserved                #
+                  #                        -***-                        #
+                  #######################################################
+
+
+                         Program Version 5.0.3 -  RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Suceptibility
+   Michael Atanasov       : Ab Initio Ligand Field Theory (pilot matlab implementation)
+   Alexander A. Auer      : GIAO ZORA, VPT2 properties, NMR spectrum
+   Ute Becker             : Parallelization
+   Giovanni Bistoni       : ED, misc. LED, open-shell LED, HFLD
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : SCF Hessian
+   Vijay G. Chilkuri      : MRCI spin determinant printing, contributions to CSF-ICE
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Miquel Garcia          : C-PCM and meta-GGA Hessian, CC/C-PCM, Gaussian charge scheme
+   Yang Guo               : DLPNO-NEVPT2, F12-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Benjamin Helmich-Paris : MC-RPA, TRAH-SCF, COSX integrals
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Marcus Kettner         : VPT2
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density, CASPT2, CASPT2-K
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, MP2 Hessian
+   Martin Krupicka        : Initial AUTO-CI
+   Lucas Lang             : DCDCAS
+   Marvin Lechner         : AUTO-CI (C++ implementation), FIC-MRCC
+   Dagmar Lenk            : GEPOL surface, SMD
+   Dimitrios Liakos       : Extrapolation schemes; Compound Job, initial MDCI parallelization
+   Dimitrios Manganas     : Further ROCIS development; embedding schemes
+   Dimitrios Pantazis     : SARC Basis sets
+   Anastasios Papadopoulos: AUTO-CI, single reference methods and gradients
+   Taras Petrenko         : DFT Hessian,TD-DFT gradient, ASA, ECA, R-Raman, ABS, FL, XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2, DLPNO-MP2 Gradient
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Tobias Risthaus        : Range-separated hybrids, TD-DFT gradient, RPA, STAB
+   Michael Roemelt        : Original ROCIS implementation
+   Masaaki Saitow         : Open-shell DLPNO-CCSD energy and density
+   Barbara Sandhoefer     : DKH picture change effects
+   Avijit Sen             : IP-ROCIS
+   Kantharuban Sivalingam : CASSCF convergence, NEVPT2, FIC-MRCI
+   Bernardo de Souza      : ESD, SOC TD-DFT
+   Georgi Stoychev        : AutoAux, RI-MP2 NMR, DLPNO-MP2 response
+   Willem Van den Heuvel  : Paramagnetic NMR
+   Boris Wezisla          : Elementary symmetry handling
+   Frank Wennmohs         : Technical directorship
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse, P. Pracht,  : VdW corrections, initial TS optimization,
+                  C. Bannwarth, S. Ehlert          DFT functionals, gCP, sTDA/sTD-DF
+   Ed Valeev, F. Pavosevic, A. Kumar             : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Jiri Pittner, Ondrej Demel                    : Mk-CCSD
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+   Lars Goerigk                                  : TD-DFT with DH, B97 family of functionals
+   V. Asgeirsson, H. Jonsson                     : NEB implementation
+   FAccTs GmbH                                   : IRC, NEB, NEB-TS, DLPNO-Multilevel, CI-OPT
+                                                   MM, QMMM, 2- and 3-layer-ONIOM, Crystal-QMMM,
+                                                   LR-CPCM, SF, NACMEs, symmetry and pop. for TD-DFT,
+                                                   nearIR, NL-DFT gradient (VV10), updates on ESD,
+                                                   ML-optimized integration grids
+   S Lehtola, MJT Oliveira, MAL Marques          : LibXC Library
+   Liviu Ungur et al                             : ANISO software
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ Your ORCA version has been built with support for libXC version: 5.1.0
+ For citations please refer to: https://tddft.org/programs/libxc/
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+   Shared memory     :  Shared parallel matrices
+   BLAS/LAPACK       :  OpenBLAS 0.3.15  USE64BITINT DYNAMIC_ARCH NO_AFFINITY SkylakeX SINGLE_THREADED
+        Core in use  :  SkylakeX
+   Copyright (c) 2011-2014, The OpenBLAS Project
+
+
+
+
+***************************************
+The coordinates will be read from file: water.xyz
+***************************************
+
+
+================================================================================
+
+----- Orbital basis set information -----
+Your calculation utilizes the basis: def2-SVP
+   F. Weigend and R. Ahlrichs, Phys. Chem. Chem. Phys. 7, 3297 (2005).
+
+----- AuxJ basis set information -----
+Your calculation utilizes the AutoAux generation procedure.
+  G. L. Stoychev, A. A. Auer, F. Neese, J. Chem. Theory Comput. 13, 554 (2017)
+
+----- AuxC basis set information -----
+Your calculation utilizes the AutoAux generation procedure.
+  G. L. Stoychev, A. A. Auer, F. Neese, J. Chem. Theory Comput. 13, 554 (2017)
+
+----- AuxJK basis set information -----
+Your calculation utilizes the AutoAux generation procedure.
+  G. L. Stoychev, A. A. Auer, F. Neese, J. Chem. Theory Comput. 13, 554 (2017)
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+
+WARNING: your system is open-shell and RHF/RKS was chosen
+  ===> : WILL SWITCH to UHF/UKS
+
+
+WARNING: Post HF methods need fully converged wavefunctions
+  ===> : Setting SCFConvForced true
+         You can overwrite this default with %scf ConvForced false 
+
+
+WARNING: PNO calculations with unrestricted orbitals require UNOs
+  ===> : Switching on UNOs
+
+WARNING: Unrestricted DLPNO-CCSD(T0/T) with FullLMP2-Guess requested.
+         This is not yet implemented.
+         When comparing energies between closed and open shell calculations:
+  ===> : Be aware to set UseFullLMP2Guess to false for the corresponding closed shell calculations.
+         Note that UseFullLMP2Guess is done by default only for TightPNO closed shell calculations.
+
+
+WARNING: MDCI localization with Augmented Hessian Foster-Boys
+  ===> : Switching off randomization!
+
+INFO   : the flag for use of the SHARK integral package has been found!
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = water_spe_CCSD.inp
+|  1> %pal
+|  2>   nprocs 4
+|  3> end
+|  4> 
+|  5> %maxcore 350
+|  6> 
+|  7> ! DLPNO-CCSD def2-SVP
+|  8> ! RIJCOSX AutoAux
+|  9> 
+| 10> * xyzfile 1 2 water.xyz
+| 11> 
+| 12>                          ****END OF INPUT****
+================================================================================
+
+                       ****************************
+                       * Single Point Calculation *
+                       ****************************
+
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O     -3.210350   -0.585040   -0.013950
+  H     -2.242470   -0.618270    0.018480
+  H     -3.489200   -1.249110    0.634290
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999   -6.066682   -1.105565   -0.026362
+   1 H     1.0000    0     1.008   -4.237654   -1.168361    0.034922
+   2 H     1.0000    0     1.008   -6.593632   -2.360476    1.198634
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ H      1   0   0     0.968993102246     0.00000000     0.00000000
+ H      1   2   0     0.969000198658   103.97800340     0.00000000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ H      1   0   0     1.831131588903     0.00000000     0.00000000
+ H      1   2   0     1.831144999180   103.97800340     0.00000000
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 2 groups of distinct atoms
+
+ Group   1 Type O   : 7s4p1d contracted to 3s2p1d pattern {511/31/1}
+ Group   2 Type H   : 4s1p contracted to 2s1p pattern {31/1}
+
+Atom   0O    basis set group =>   1
+Atom   1H    basis set group =>   2
+Atom   2H    basis set group =>   2
+---------------------------------
+AUXILIARY/J BASIS SET INFORMATION
+---------------------------------
+There are 2 groups of distinct atoms
+
+ Group   1 Type O   : 14s11p10d2f contracted to 14s11p10d2f pattern {11111111111111/11111111111/1111111111/11}
+ Group   2 Type H   : 9s2p1d contracted to 9s2p1d pattern {111111111/11/1}
+
+Atom   0O    basis set group =>   1
+Atom   1H    basis set group =>   2
+Atom   2H    basis set group =>   2
+---------------------------------
+AUXILIARY/C BASIS SET INFORMATION
+---------------------------------
+There are 2 groups of distinct atoms
+
+ Group   1 Type O   : 14s11p10d2f contracted to 14s11p10d2f pattern {11111111111111/11111111111/1111111111/11}
+ Group   2 Type H   : 9s2p1d contracted to 9s2p1d pattern {111111111/11/1}
+
+Atom   0O    basis set group =>   1
+Atom   1H    basis set group =>   2
+Atom   2H    basis set group =>   2
+----------------------------------
+AUXILIARY/JK BASIS SET INFORMATION
+----------------------------------
+There are 2 groups of distinct atoms
+
+ Group   1 Type O   : 14s11p10d2f contracted to 14s11p10d2f pattern {11111111111111/11111111111/1111111111/11}
+ Group   2 Type H   : 9s2p1d contracted to 9s2p1d pattern {111111111/11/1}
+
+Atom   0O    basis set group =>   1
+Atom   1H    basis set group =>   2
+Atom   2H    basis set group =>   2
+
+
+           ************************************************************
+           *        Program running with 4 parallel MPI-processes     *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                           ORCA GTO INTEGRAL CALCULATION
+                           -- RI-GTO INTEGRALS CHOSEN --
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021                                                         
+------------------------------------------------------------------------------
+
+
+Reading SHARK input file water_spe_CCSD.SHARKINP.tmp ... ok
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...      3
+Number of basis functions                   ...     24
+Number of shells                            ...     12
+Maximum angular momentum                    ...      2
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+Auxiliary Coulomb fitting basis             ... AVAILABLE
+   # of basis functions in Aux-J            ...    151
+   # of shells in Aux-J                     ...     61
+   Maximum angular momentum in Aux-J        ...      3
+Auxiliary J/K fitting basis                 ... AVAILABLE
+   # of basis functions in Aux-JK           ...    151
+   # of shells in Aux-JK                    ...     61
+   Maximum angular momentum in Aux-JK       ...      3
+Auxiliary Correlation fitting basis         ... AVAILABLE
+   # of basis functions in Aux-C            ...    151
+   # of shells in Aux-C                     ...     61
+   Maximum angular momentum in Aux-C        ...      3
+Auxiliary 'external' fitting basis          ... NOT available
+Integral threshold                          ...     1.000000e-10
+Primitive cut-off                           ...     1.000000e-11
+Primitive pair pre-selection threshold      ...     1.000000e-11
+
+Calculating pre-screening integrals         ... done (  0.0 sec) Dimension = 12
+Organizing shell pair data                  ... done (  0.0 sec)
+Shell pair information
+Total number of shell pairs                 ...        78
+Shell pairs after pre-screening             ...        78
+Total number of primitive shell pairs       ...       272
+Primitive shell pairs kept                  ...       265
+          la=0 lb=0:     28 shell pairs
+          la=1 lb=0:     28 shell pairs
+          la=1 lb=1:     10 shell pairs
+          la=2 lb=0:      7 shell pairs
+          la=2 lb=1:      4 shell pairs
+          la=2 lb=2:      1 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating RI/J V-Matrix + Cholesky decomp.... done (  0.0 sec)
+Calculating RI/JK V-Matrix + Cholesky decomp... done (  0.0 sec)
+Calculating RI/C V-Matrix + Cholesky decomp.... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=      9.084297099237 Eh
+
+SHARK setup successfully completed in   0.1 seconds
+
+Maximum memory used throughout the entire GTOINT-calculation: 7.6 MB
+
+
+           ************************************************************
+           *        Program running with 4 parallel MPI-processes     *
+           *              working on a common directory               *
+           ************************************************************
+-------------------------------------------------------------------------------
+                                 ORCA SCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Ab initio Hamiltonian  Method          .... Hartree-Fock(GTOs)
+ RI-approximation to the Coulomb term is turned on
+   Number of AuxJ basis functions       .... 151
+   RIJ-COSX (HFX calculated with COS-X)).... on
+
+
+General Settings:
+ Integral files         IntName         .... water_spe_CCSD
+ Hartree-Fock type      HFTyp           .... UHF
+ Total Charge           Charge          ....    1
+ Multiplicity           Mult            ....    2
+ Number of Electrons    NEL             ....    9
+ Basis Dimension        Dim             ....   24
+ Nuclear Repulsion      ENuc            ....      9.0842970992 Eh
+
+Convergence Acceleration:
+ DIIS                   CNVDIIS         .... on
+   Start iteration      DIISMaxIt       ....    12
+   Startup error        DIISStart       ....  0.200000
+   # of expansion vecs  DIISMaxEq       ....     5
+   Bias factor          DIISBfac        ....   1.050
+   Max. coefficient     DIISMaxC        ....  10.000
+ Trust-Rad. Augm. Hess. CNVTRAH         .... auto
+   Auto Start mean grad. ratio tolernc. ....  1.125000
+   Auto Start start iteration           ....    20
+   Auto Start num. interpolation iter.  ....    10
+   Max. Number of Micro iterations      ....    16
+   Max. Number of Macro iterations      .... Maxiter - #DIIS iter
+   Number of Davidson start vectors     ....     2
+   Converg. threshold I  (grad. norm)   ....   5.000e-05
+   Converg. threshold II (energy diff.) ....   1.000e-06
+   Grad. Scal. Fac. for Micro threshold ....   0.100
+   Minimum threshold for Micro iter.    ....   0.010
+   NR start threshold (gradient norm)   ....   0.001
+   Initial trust radius                 ....   0.400
+   Minimum AH scaling param. (alpha)    ....   1.000
+   Maximum AH scaling param. (alpha)    .... 1000.000
+   Orbital update algorithm             .... Taylor
+   White noise on init. David. guess    .... on
+   Maximum white noise                  ....   0.010
+   Quad. conv. algorithm                .... NR
+ SOSCF                  CNVSOSCF        .... off
+ Level Shifting         CNVShift        .... on
+   Level shift para.    LevelShift      ....    0.2500
+   Turn off err/grad.   ShiftErr        ....    0.0010
+ Zerner damping         CNVZerner       .... off
+ Static damping         CNVDamp         .... on
+   Fraction old density DampFac         ....    0.7000
+   Max. Damping (<1)    DampMax         ....    0.9800
+   Min. Damping (>=0)   DampMin         ....    0.0000
+   Turn off err/grad.   DampErr         ....    0.1000
+ Fernandez-Rico         CNVRico         .... off
+
+SCF Procedure:
+ Maximum # iterations   MaxIter         ....   125
+ SCF integral mode      SCFMode         .... Direct
+   Integral package                     .... SHARK and LIBINT hybrid scheme
+ Reset frequency        DirectResetFreq ....    20
+ Integral Threshold     Thresh          ....  1.000e-10 Eh
+ Primitive CutOff       TCut            ....  1.000e-11 Eh
+
+Convergence Tolerance:
+ Convergence Check Mode ConvCheckMode   .... Total+1el-Energy
+ Convergence forced     ConvForced      .... 1
+ Energy Change          TolE            ....  1.000e-06 Eh
+ 1-El. energy change                    ....  1.000e-03 Eh
+ DIIS Error             TolErr          ....  1.000e-06
+
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 3.830e-02
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.000 sec
+Total time needed                          ...    0.001 sec
+
+Time for model grid setup =    0.009 sec
+
+------------------------------
+INITIAL GUESS: MODEL POTENTIAL
+------------------------------
+Loading Hartree-Fock densities                     ... done
+Calculating cut-offs                               ... done
+Initializing the effective Hamiltonian             ... done
+Setting up the integral package (SHARK)            ... done
+Starting the Coulomb interaction                   ... done (   0.0 sec)
+Reading the grid                                   ... done
+Mapping shells                                     ... done
+Starting the XC term evaluation                    ... done (   0.0 sec)
+Transforming the Hamiltonian                       ... done (   0.0 sec)
+Diagonalizing the Hamiltonian                      ... done (   0.0 sec)
+Back transforming the eigenvectors                 ... done (   0.0 sec)
+Now organizing SCF variables                       ... done
+                      ------------------
+                      INITIAL GUESS DONE (   0.0 sec)
+                      ------------------
+--------------------
+COSX GRID GENERATION
+--------------------
+
+GRIDX 1
+-------
+General Integration Accuracy     IntAcc      ... 3.816
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 1 (Lebedev-50)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ... 1.0000e-10
+Integration weight cutoff        WCut        ... 1.0000e-14
+Angular grids for H and He will be reduced by one unit
+Partially contracted basis set               ... on
+Rotationally invariant grid construction     ... off
+
+Total number of grid points                  ...     1658
+Total number of batches                      ...       27
+Average number of points per batch           ...       61
+Average number of grid points per atom       ...      553
+UseSFitting                                  ... on
+
+GRIDX 2
+-------
+General Integration Accuracy     IntAcc      ... 4.020
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 2 (Lebedev-110)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ... 1.0000e-10
+Integration weight cutoff        WCut        ... 1.0000e-14
+Angular grids for H and He will be reduced by one unit
+Partially contracted basis set               ... on
+Rotationally invariant grid construction     ... off
+
+Total number of grid points                  ...     3504
+Total number of batches                      ...       57
+Average number of points per batch           ...       61
+Average number of grid points per atom       ...     1168
+UseSFitting                                  ... on
+
+GRIDX 3
+-------
+General Integration Accuracy     IntAcc      ... 4.338
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 3 (Lebedev-194)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ... 1.0000e-10
+Integration weight cutoff        WCut        ... 1.0000e-14
+Angular grids for H and He will be reduced by one unit
+Partially contracted basis set               ... on
+Rotationally invariant grid construction     ... off
+
+Total number of grid points                  ...     7763
+Total number of batches                      ...      123
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     2588
+UseSFitting                                  ... on
+
+Time for X-Grid setup             =    0.035 sec
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+               ***  Starting incremental Fock matrix formation  ***
+  0    -75.5460638554   0.000000000000 0.00912392  0.00084262  0.0640291 0.7000
+  1    -75.5502986181  -0.004234762657 0.00764489  0.00072540  0.0495229 0.7000
+                               ***Turning on DIIS***
+  2    -75.5535402883  -0.003241670247 0.01946202  0.00187401  0.0378209 0.0000
+  3    -75.5537686844  -0.000228396130 0.00737652  0.00056412  0.0096727 0.0000
+  4    -75.5660469839  -0.012278299500 0.00420231  0.00030627  0.0039417 0.0000
+  5    -75.5621182112   0.003928772763 0.00273734  0.00020028  0.0027648 0.0000
+  6    -75.5625834721  -0.000465260970 0.00138095  0.00012039  0.0011588 0.0000
+  7    -75.5628816537  -0.000298181507 0.00062576  0.00005445  0.0004184 0.0000
+               *** Restarting incremental Fock matrix formation ***
+                                   *** Resetting DIIS ***
+  8    -75.5630268717  -0.000145218072 0.00013189  0.00000999  0.0001266 0.0000
+  9    -75.5629580622   0.000068809521 0.00005552  0.00000523  0.0000680 0.0000
+ 10    -75.5630553001  -0.000097237937 0.00004414  0.00000356  0.0000421 0.0000
+ 11    -75.5630462316   0.000009068526 0.00002161  0.00000166  0.0000174 0.0000
+ 12    -75.5630245661   0.000021665523 0.00000527  0.00000043  0.0000035 0.0000
+                            ***DIIS convergence achieved***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER  13 CYCLES          *
+               *****************************************************
+
+Old exchange energy                            =     -8.631202843 Eh
+New exchange energy                            =     -8.631331318 Eh
+Exchange energy change after final integration =     -0.000128475 Eh
+Total energy after final integration           =    -75.563156480 Eh
+Final COS-X integration done in                =     0.041 sec
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :          -75.56315648 Eh           -2056.17802 eV
+
+Components:
+Nuclear Repulsion  :            9.08429710 Eh             247.19629 eV
+Electronic Energy  :          -84.64745358 Eh           -2303.37431 eV
+One Electron Energy:         -117.79622395 Eh           -3205.39821 eV
+Two Electron Energy:           33.14877037 Eh             902.02390 eV
+Max COSX asymmetry :            0.00000087 Eh               0.00002 eV
+
+Virial components:
+Potential Energy   :         -151.08063262 Eh           -4111.11302 eV
+Kinetic Energy     :           75.51747614 Eh            2054.93500 eV
+Virial Ratio       :            2.00060490
+
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...   -3.4388e-06  Tolerance :   1.0000e-06
+  Last MAX-Density change    ...    0.0000e+00  Tolerance :   1.0000e-05
+  Last RMS-Density change    ...    0.0000e+00  Tolerance :   1.0000e-06
+  Last DIIS Error            ...    1.2915e-06  Tolerance :   1.0000e-06
+
+             **** THE GBW FILE WAS UPDATED (water_spe_CCSD.gbw) ****
+             **** DENSITY water_spe_CCSD.scfp WAS UPDATED ****
+             **** ENERGY FILE WAS UPDATED (water_spe_CCSD.en.tmp) ****
+----------------------
+UHF SPIN CONTAMINATION
+----------------------
+
+Expectation value of <S**2>     :     0.756454
+Ideal value S*(S+1) for S=0.5   :     0.750000
+Deviation                       :     0.006454
+
+             **** THE GBW FILE WAS UPDATED (water_spe_CCSD.gbw) ****
+             **** DENSITY water_spe_CCSD.scfp WAS UPDATED ****
+----------------
+ORBITAL ENERGIES
+----------------
+                 SPIN UP ORBITALS
+  NO   OCC          E(Eh)            E(eV) 
+   0   1.0000     -21.131888      -575.0279 
+   1   1.0000      -1.886941       -51.3463 
+   2   1.0000      -1.213746       -33.0277 
+   3   1.0000      -1.132618       -30.8201 
+   4   1.0000      -1.096615       -29.8404 
+   5   0.0000      -0.146449        -3.9851 
+   6   0.0000      -0.062551        -1.7021 
+   7   0.0000       0.390249        10.6192 
+   8   0.0000       0.451709        12.2916 
+   9   0.0000       0.675977        18.3943 
+  10   0.0000       0.733000        19.9459 
+  11   0.0000       0.841334        22.8939 
+  12   0.0000       0.896597        24.3976 
+  13   0.0000       1.155810        31.4512 
+  14   0.0000       1.225951        33.3598 
+  15   0.0000       1.362777        37.0830 
+  16   0.0000       1.644758        44.7561 
+  17   0.0000       2.077140        56.5218 
+  18   0.0000       2.086627        56.7800 
+  19   0.0000       2.760023        75.1041 
+  20   0.0000       2.809282        76.4444 
+  21   0.0000       3.052032        83.0500 
+  22   0.0000       3.351152        91.1895 
+  23   0.0000       3.732204       101.5584 
+
+                 SPIN DOWN ORBITALS
+  NO   OCC          E(Eh)            E(eV) 
+   0   1.0000     -21.085644      -573.7695 
+   1   1.0000      -1.732061       -47.1318 
+   2   1.0000      -1.175089       -31.9758 
+   3   1.0000      -1.043822       -28.4038 
+   4   0.0000      -0.314028        -8.5451 
+   5   0.0000      -0.133116        -3.6223 
+   6   0.0000      -0.054110        -1.4724 
+   7   0.0000       0.388662        10.5760 
+   8   0.0000       0.470062        12.7910 
+   9   0.0000       0.757940        20.6246 
+  10   0.0000       0.859792        23.3961 
+  11   0.0000       0.873478        23.7685 
+  12   0.0000       0.929002        25.2794 
+  13   0.0000       1.187101        32.3027 
+  14   0.0000       1.244793        33.8726 
+  15   0.0000       1.394463        37.9453 
+  16   0.0000       1.641027        44.6546 
+  17   0.0000       2.088174        56.8221 
+  18   0.0000       2.151370        58.5417 
+  19   0.0000       2.862463        77.8916 
+  20   0.0000       2.913017        79.2672 
+  21   0.0000       3.082227        83.8717 
+  22   0.0000       3.424837        93.1945 
+  23   0.0000       3.750195       102.0480 
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+--------------------------------------------
+MULLIKEN ATOMIC CHARGES AND SPIN POPULATIONS
+--------------------------------------------
+   0 O :    0.363044    1.095193
+   1 H :    0.318447   -0.047592
+   2 H :    0.318509   -0.047601
+Sum of atomic charges         :    1.0000000
+Sum of atomic spin populations:    1.0000000
+
+-----------------------------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES AND SPIN POPULATIONS
+-----------------------------------------------------
+CHARGE
+  0 O s       :     3.713891  s :     3.713891
+      pz      :     1.241806  p :     3.910611
+      px      :     1.414309
+      py      :     1.254497
+      dz2     :     0.001819  d :     0.012455
+      dxz     :     0.000739
+      dyz     :     0.004414
+      dx2y2   :     0.004720
+      dxy     :     0.000763
+  1 H s       :     0.606017  s :     0.606017
+      pz      :     0.010680  p :     0.075536
+      px      :     0.053976
+      py      :     0.010879
+  2 H s       :     0.605959  s :     0.605959
+      pz      :     0.027207  p :     0.075531
+      px      :     0.020104
+      py      :     0.028221
+
+SPIN
+  0 O s       :     0.048731  s :     0.048731
+      pz      :     0.517431  p :     1.046992
+      px      :     0.035345
+      py      :     0.494216
+      dz2     :     0.000196  d :    -0.000531
+      dxz     :     0.000132
+      dyz     :    -0.000714
+      dx2y2   :    -0.000272
+      dxy     :     0.000127
+  1 H s       :    -0.053037  s :    -0.053037
+      pz      :     0.003097  p :     0.005445
+      px      :    -0.000572
+      py      :     0.002920
+  2 H s       :    -0.053047  s :    -0.053047
+      pz      :     0.003156  p :     0.005446
+      px      :    -0.000694
+      py      :     0.002983
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+-------------------------------------------
+LOEWDIN ATOMIC CHARGES AND SPIN POPULATIONS
+-------------------------------------------
+   0 O :    0.592571    1.017846
+   1 H :    0.203716   -0.008919
+   2 H :    0.203713   -0.008927
+
+----------------------------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES AND SPIN POPULATIONS
+----------------------------------------------------
+CHARGE
+  0 O s       :     3.455648  s :     3.455648
+      pz      :     1.241029  p :     3.932386
+      px      :     1.436268
+      py      :     1.255088
+      dz2     :     0.002747  d :     0.019394
+      dxz     :     0.000839
+      dyz     :     0.006746
+      dx2y2   :     0.008187
+      dxy     :     0.000875
+  1 H s       :     0.627303  s :     0.627303
+      pz      :     0.026649  p :     0.168981
+      px      :     0.115407
+      py      :     0.026925
+  2 H s       :     0.627306  s :     0.627306
+      pz      :     0.065017  p :     0.168981
+      px      :     0.036774
+      py      :     0.067190
+
+SPIN
+  0 O s       :     0.025901  s :     0.025901
+      pz      :     0.497399  p :     0.993359
+      px      :     0.021361
+      py      :     0.474599
+      dz2     :    -0.000122  d :    -0.001414
+      dxz     :    -0.000024
+      dyz     :    -0.000504
+      dx2y2   :    -0.000733
+      dxy     :    -0.000030
+  1 H s       :    -0.035456  s :    -0.035456
+      pz      :     0.010568  p :     0.026537
+      px      :     0.005921
+      py      :     0.010048
+  2 H s       :    -0.035465  s :    -0.035465
+      pz      :     0.013324  p :     0.026538
+      px      :     0.000273
+      py      :     0.012941
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 O      7.6370     8.0000     0.3630     2.7939     1.8102     0.9837
+  1 H      0.6816     1.0000     0.3184     0.9206     0.9175     0.0032
+  2 H      0.6815     1.0000     0.3185     0.9206     0.9174     0.0032
+
+  Mayer bond orders larger than 0.100000
+B(  0-O ,  1-H ) :   0.9051 B(  0-O ,  2-H ) :   0.9051 
+
+
+                ***UHF Natural Orbitals were saved in water_spe_CCSD.unso***
+
+
+                ***UHF Natural Orbitals were saved in water_spe_CCSD.uno***
+
+QR-MO GENERATION
+ Dim     =   24
+ Mult    =    2
+ NEl     =    9
+ N(DOMO) =    4
+ N(SOMO) =    1
+ N(VMO)  =   19
+
+
+                ***Quasi-Restricted Orbitals were saved in water_spe_CCSD.qro***
+
+Orbital Energies of Quasi-Restricted MO's
+   0( 2) :   -21.085627 a.u.  -573.769 eV
+   1( 2) :    -1.729365 a.u.   -47.058 eV
+   2( 2) :    -1.174458 a.u.   -31.959 eV
+   3( 2) :    -1.043417 a.u.   -28.393 eV
+   4( 1) :    -0.699907 a.u.   -19.045 eV alpha=  -30.820 beta=   -7.271
+   5( 0) :    -0.146957 a.u.    -3.999 eV
+   6( 0) :    -0.062846 a.u.    -1.710 eV
+   7( 0) :     0.390036 a.u.    10.613 eV
+   8( 0) :     0.450855 a.u.    12.268 eV
+   9( 0) :     0.675977 a.u.    18.394 eV
+  10( 0) :     0.732691 a.u.    19.938 eV
+  11( 0) :     0.841241 a.u.    22.891 eV
+  12( 0) :     0.896593 a.u.    24.398 eV
+  13( 0) :     1.155810 a.u.    31.451 eV
+  14( 0) :     1.225772 a.u.    33.355 eV
+  15( 0) :     1.362777 a.u.    37.083 eV
+  16( 0) :     1.644752 a.u.    44.756 eV
+  17( 0) :     2.077124 a.u.    56.521 eV
+  18( 0) :     2.085851 a.u.    56.759 eV
+  19( 0) :     2.760023 a.u.    75.104 eV
+  20( 0) :     2.809282 a.u.    76.444 eV
+  21( 0) :     3.051890 a.u.    83.046 eV
+  22( 0) :     3.350771 a.u.    91.179 eV
+  23( 0) :     3.732187 a.u.   101.558 eV
+-------
+TIMINGS
+-------
+
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+
+Total time                  ....       0.804 sec
+Sum of individual times     ....       0.743 sec  ( 92.4%)
+
+Fock matrix formation       ....       0.608 sec  ( 75.6%)
+  Split-RI-J                ....       0.185 sec  ( 30.4% of F)
+  Chain of spheres X        ....       0.385 sec  ( 63.3% of F)
+Diagonalization             ....       0.030 sec  (  3.7%)
+Density matrix formation    ....       0.001 sec  (  0.1%)
+Population analysis         ....       0.017 sec  (  2.1%)
+Initial guess               ....       0.004 sec  (  0.5%)
+Orbital Transformation      ....       0.000 sec  (  0.0%)
+Orbital Orthonormalization  ....       0.000 sec  (  0.0%)
+DIIS solution               ....       0.041 sec  (  5.1%)
+
+Maximum memory used throughout the entire SCF-calculation: 41.3 MB
+
+
+           ************************************************************
+           *        Program running with 4 parallel MPI-processes     *
+           *              working on a common directory               *
+           ************************************************************
+
+
+--------------------------------------------------------------------------------
+                             ORCA-MATRIX DRIVEN CI
+--------------------------------------------------------------------------------
+
+
+Wavefunction type
+-----------------
+Correlation treatment                      ...      CCSD     
+Single excitations                         ... ON
+Orbital optimization                       ... OFF
+Calculation of Z vector                    ... OFF
+Calculation of Brueckner orbitals          ... OFF
+Perturbative triple excitations            ... OFF
+Calculation of F12 correction              ... OFF
+Frozen core treatment                      ... chemical core (2 el)
+Reference Wavefunction                     ... UHF
+  Alpha-MOs occ    :     1 ...    4 (  4 MO's/  4 electrons)
+  Beta-MOs occ     :     1 ...    3 (  3 MO's/  3 electrons)
+  Alpha-MOs virt   :     5 ...   23 ( 19 MO's              )
+  Beta-MOs virt    :     4 ...   23 ( 20 MO's              )
+  Quasi restricted orbitals will be used (this is similar to a ROHF determinant)
+Number of AO's                             ...     24
+Number of electrons                        ...      9
+Number of correlated electrons             ...      7
+
+Algorithmic settings
+--------------------
+Integral transformation                    ... All integrals via the RI transformation
+RHF integral transformation will be used
+K(C) Formation                             ... RI-DLPNO
+   PNO-Integral Storage                    ... ON DISK
+   PNO occupation number cut-off           ... 3.330e-07
+   Singles PNO occupation number cut-off   ... 9.990e-09
+   PNO Mulliken prescreening cut-off       ... 1.000e-03
+   Domain cut-off (Mulliken population)    ... 1.000e-03
+   PNO Normalization                       ...    1
+Maximum number of iterations               ...        50
+Convergence tolerance (max. residuum)      ... 2.500e-05
+Level shift for amplitude update           ... 2.000e-01
+Maximum number of DIIS vectors             ...         7
+DIIS turned on at iteration                ...         0
+Damping before turning on DIIS             ...     0.500
+Damping after turning on DIIS              ...     0.000
+Pair specific amplitude update             ... OFF
+Natural orbital iterations                 ... OFF
+Perturbative natural orbital generation    ... OFF
+Printlevel                                 ... 2
+
+Singles Fock matrix elements calculated using PNOs.
+
+Memory handling:
+----------------
+Maximum memory for working arrays          ...    350 MB
+Data storage in matrix containers          ... UNCOMPRESSED
+Data type for integral storage             ... DOUBLE
+In-Core Storage of quantities:
+   Amplitudes+Sigma Vector      ... NO
+   J+K operators                ... NO
+   DIIS vectors                 ... NO
+   3-external integrals         ... NO
+   4-external integrals         ... NO
+
+Localization treatment:
+-----------------------
+Localization option                        ...    6
+Localization threshhold                    ... -1.0e+00
+Using relative localization threshhold     ... 1.0e-08
+Neglect threshold for strong pairs         ... 1.000e-04 Eh
+Prescreening threshold for very weak pairs ... 1.000e-06 Eh
+
+Initializing the integral package          ... done
+Localizing the QROs
+------------------------------------------------------------------------------
+                           ORCA ORBITAL LOCALIZATION
+------------------------------------------------------------------------------
+
+Input orbitals are from                  ... water_spe_CCSD.qro
+Output orbitals are to                   ... water_spe_CCSD.loc
+Max. number of iterations                ... 128
+Localizations seeded randomly            ... off
+Convergence tolerance                    ... 1.000e-06
+Using relative localization threshhold   ... 1.000e-08
+Treshold for strong local MOs            ... 9.500e-01
+Treshold for bond MOs                    ... 8.500e-01
+Operator                                 ... 0
+Orbital range for localization           ... 1 to 3
+Localization criterion                   ... FOSTER-BOYS (AUGMENTED HESSIAN)
+Doing the dipole integrals     ... o.k.
+Initial value of the localization sum :   111.530713
+ITERATION   0 : L=  113.0757278210 DL=  1.55e+00 (AVERGE_DL)=    0.7176385252 
+ITERATION   1 : L=  113.0895815591 DL=  1.39e-02 (AVERGE_DL)=    0.0679552257 
+ITERATION   2 : L=  113.0896016614 DL=  2.01e-05 (AVERGE_DL)=    0.0025885812 
+ITERATION   3 : L=  113.0896026841 DL=  1.02e-06 (AVERGE_DL)=    0.0005838763 
+ITERATION   4 : L=  113.0896027011 DL=  1.70e-08 (AVERGE_DL)=    0.0000752938 
+LOCALIZATION SUM CONVERGED
+
+------------------------------------------------------
+AUGMENTED HESSIAN OPTIMIZATION OF FOSTER-BOYS ORBITALS
+------------------------------------------------------
+
+Spin operator:           0
+Orbital window:          1 to 3
+Number of iterations:    128
+Gradient tolerance:      1.000e-06
+Number of pairs:         3
+Davidson threshold:      2000
+Diagonalization method:  LAPACK
+Iter:    0   L: 113.0896027011   Grad. norm: 6.702715e-05
+   *** Likely close to a maximum now. ***
+       Augmented Hessian eigenvalues:  8.48e-10 -4.38e+00 -7.71e+00 -9.01e+00
+Iter:    1   L: 113.0896027015   Grad. norm: 1.441091e-10
+LOCALIZATION HAS CONVERGED.
+
+Eigenvalues of the Hessian:
+  0 -4.378e+00
+  1 -7.711e+00
+  2 -9.007e+00
+
+
+--------------------------------------------------------------------------------
+                    LOCALIZED MOLECULAR ORBITAL COMPOSITIONS
+--------------------------------------------------------------------------------
+
+The Mulliken populations for each LMO on each atom are computed
+The LMO`s will be ordered according to atom index and type
+  (A) Strongly localized MO`s have populations of >=0.950 on one atom
+  (B) Two center bond orbitals have populations of >=0.850 on two atoms
+  (C) Other MO`s are considered to be `delocalized`
+
+FOUND  -   1 strongly local MO`s
+       -   2 two center bond MO`s
+       -   0 significantly delocalized MO`s
+
+Rather strongly localized orbitals:
+MO   1:   0O  -   1.004535
+Bond-like localized orbitals:
+MO   3:   2H  -   0.339137  and   0O  -   0.660319
+MO   2:   1H  -   0.339174  and   0O  -   0.660284
+Localized MO's were stored in: water_spe_CCSD.loc
+
+------------------------------------------------------------------------------
+                           ORCA ORBITAL LOCALIZATION
+------------------------------------------------------------------------------
+
+Input orbitals are from                  ... water_spe_CCSD.loc
+Output orbitals are to                   ... water_spe_CCSD.loc
+Max. number of iterations                ... 128
+Localizations seeded randomly            ... off
+Convergence tolerance                    ... 1.000e-06
+Using relative localization threshhold   ... 1.000e-08
+Treshold for strong local MOs            ... 9.500e-01
+Treshold for bond MOs                    ... 8.500e-01
+Operator                                 ... 0
+Orbital range for localization           ... 4 to 4
+Localization criterion                   ... FOSTER-BOYS (AUGMENTED HESSIAN)
+Doing the dipole integrals     ... o.k.
+
+ORCA_LOC: ONLY ONE ORBITAL - SKIPPING LOCALIZATION
+
+
+--------------------------------------------------------------------------------
+                    LOCALIZED MOLECULAR ORBITAL COMPOSITIONS
+--------------------------------------------------------------------------------
+
+The Mulliken populations for each LMO on each atom are computed
+The LMO`s will be ordered according to atom index and type
+  (A) Strongly localized MO`s have populations of >=0.950 on one atom
+  (B) Two center bond orbitals have populations of >=0.850 on two atoms
+  (C) Other MO`s are considered to be `delocalized`
+
+FOUND  -   1 strongly local MO`s
+       -   0 two center bond MO`s
+       -   0 significantly delocalized MO`s
+
+Rather strongly localized orbitals:
+MO   4:   0O  -   0.986684
+Localized MO's were stored in: water_spe_CCSD.loc
+
+Localizing the core orbitals
+------------------------------------------------------------------------------
+                           ORCA ORBITAL LOCALIZATION
+------------------------------------------------------------------------------
+
+Input orbitals are from                  ... water_spe_CCSD.loc
+Output orbitals are to                   ... water_spe_CCSD.loc
+Max. number of iterations                ... 128
+Localizations seeded randomly            ... off
+Convergence tolerance                    ... 1.000e-06
+Using relative localization threshhold   ... 1.000e-08
+Treshold for strong local MOs            ... 9.500e-01
+Treshold for bond MOs                    ... 8.500e-01
+Operator                                 ... 0
+Orbital range for localization           ... 0 to 0
+Localization criterion                   ... FOSTER-BOYS (AUGMENTED HESSIAN)
+Doing the dipole integrals     ... o.k.
+
+ORCA_LOC: ONLY ONE ORBITAL - SKIPPING LOCALIZATION
+
+
+--------------------------------------------------------------------------------
+                    LOCALIZED MOLECULAR ORBITAL COMPOSITIONS
+--------------------------------------------------------------------------------
+
+The Mulliken populations for each LMO on each atom are computed
+The LMO`s will be ordered according to atom index and type
+  (A) Strongly localized MO`s have populations of >=0.950 on one atom
+  (B) Two center bond orbitals have populations of >=0.850 on two atoms
+  (C) Other MO`s are considered to be `delocalized`
+
+FOUND  -   1 strongly local MO`s
+       -   0 two center bond MO`s
+       -   0 significantly delocalized MO`s
+
+Rather strongly localized orbitals:
+MO   0:   0O  -   1.000397
+Localized MO's were stored in: water_spe_CCSD.loc
+
+Re-Reading QRO orbitals for the actual calculation
+  ... duplicating orbitals and energies 
+  ... adjusting occupation numbers
+Warning: reference  - re-canonicalizations have been set to INT 1 VIRT 1
+Warning: internal orbitals are localized - no re-canonicalization of internal orbitals
+Warning: UsePNO is turned on - no re-canonicalization of internal and virtual orbitals
+
+--------------
+DLPNO SETTINGS
+--------------
+
+TCutMKN:           1.000e-03
+TCutPAO:           1.000e-03
+TCutPNO:           3.330e-07
+TCutPNOSingles:    9.990e-09
+TCutPAOExt:        1.000e-01
+TCutPairs:         1.000e-04
+TCutPre:           1.000e-06
+TCutDOij:          1.000e-05
+PAO overlap thresh 1.000e-08
+Number of singly-occupied orbitals: 1
+Using PNOs for Singles Fock computation
+--------------------------
+Dim 24, Dim + NT + NS 25
+Reading one-electron matrix from water_spe_CCSD.H.tmp ...done
+Entering RIJCOSX section for the open-shell Fock matrices
+Calculating the full J-matrix                     ... done
+Calculating all K-matrices                        ... done
+RIJCOSX finished
+Reference energy                           ...    -75.558526732
+Calculating differential overlap integrals (occ,PAO) ... ok
+ >> Construction of the PNO with the Koopmans (K)-matrix << 
+Entering the RI transformation section
+
+-----------------
+RI-TRANSFORMATION (AUX index driven)
+-----------------
+
+Dimension of the orbital-basis         ... 24
+Dimension of the aux-basis             ... 151
+Transformation of internal MOs         ...    4-   4
+Number Format for Storage              ... Double (8 Byte)
+Integral mode                          ... Direct
+
+First Phase: integral generation and transformation of MO indices
+  Aux angular momentum 0               ... done (    0.000 sec)
+  Aux angular momentum 1               ... done (    0.000 sec)
+  Aux angular momentum 2               ... done (    0.000 sec)
+  Aux angular momentum 3               ... done (    0.000 sec)
+Closing buffer VIJ ( 0.00 GB; CompressionRatio= 0.40)
+  Phase 1 completed in     0.087 sec
+Second Phase: sorting and transformation of aux index
+
+IJ-Transformation
+Memory available                       ... 350 MB 
+Max. # MO pairs treated in a batch     ... 1    
+# of internal orbitals                 ... 1
+# batches for internal orbitals        ... 1
+Closing buffer IJV ( 0.00 GB; CompressionRatio= 0.99)
+(ij|v) transformation done in     0.000 sec
+
+  Phase 2 completed in     0.001 sec
+RI-Integral transformation completed in     0.088 sec
+
+-----------------------
+RI-FORMATION OF (ij|kl)
+-----------------------
+
+Max core memory to be used            ... 350 MB
+Memory needed per MO pair             ...   0.0 MB
+# of MO pairs included in trafo       ... 1
+# of MO pairs treated in a batch      ... 1
+# of batches needed                   ... 1
+Data format used                      ... DOUBLE
+ done (    0.000 sec)
+Closing buffer JIJ ( 0.00 GB; CompressionRatio= 0.40)
+(ij|kl) transformation completed in     0.001 sec
+     ... leaving the RI transformation section
+ >> 4-active ERIs are generated & stored in-core fast memory 
+ >> End construction..
+F12 correction will NOT be calculated
+ >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 
+       Dipole-based Prescreening       
+ <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< 
+Threshold for domain construction in prescreening:
+   TCutDO    ...     1.0e-02
+--------------------------
+ELECTRON PAIR PRESCREENING
+--------------------------
+
+PAO based multipole pair screening          .... used
+   TCutDOij = 1.000000e-05
+   TCutPre  = 1.000000e-06
+ done
+
+sum of pair energies estimated for screened out pairs ...       0.000000000000 Eh
+                                                           
+  __   __        __   ___     __        ___  __   __       
+ /  ` |__) |  | |  \ |__     / _` |  | |__  /__` /__`     
+ \__, |  \ \__/ |__/ |___    \__> \__/ |___ .__/ .__/ 
+                                                           
+
+Parameters for the crude guess:
+   TScaleDOMP2PreScr   : 2.000e+00
+   TScaleMKNMP2PreScr  : 1.000e+01
+   TScalePNOMP2PreScr  : 1.000e+00
+   TScalePairsMP2PreScr: 1.000e+00
+   PAO overlap thresh    1.000e-08
+Thresholds for map construction and integral transformation for crude MP2:
+   TCutMKN                    ...     1.0e-02
+   TCutDO                     ...     2.0e-02
+   TCutPairs                  ...     1.0e-04
+   TCutPairs_CrudeMP2         ...     1.0e-04
+   TCutPNO_CrudeMP2           ...     3.3e-07
+   TCutPNOSingles_CrudeMP2    ...     1.0e-08
+
+CRUDE: Average # of AOs per PAO                   ...    24.0
+CRUDE: Average # of atoms per PAO                 ...     3.0
+CRUDE: Average # of atoms per a pair domain       ...    3.00
+CRUDE: Average # of atoms per AUX domain          ...    1.50
+CRUDE: Average # of atoms per a pair AUX domain   ...    1.92
+
+ * Extended Maps .. 
+CRUDE: Average # of PAOs (Atoms) per Occ          ...     3.0
+CRUDE: Average # of PAOs (AOs) per Occ            ...    25.0
+
+ * Trafo Maps .. 
+CRUDE: Average # of PAOs (Atoms) per Occ (Trafo)  ...     3.0
+CRUDE: Average # of PAOs (AOs) per Occ (Trafo)    ...    25.0
+CRUDE: Average # of AUX (Atoms) per Occ (Trafo)   ...     3.0
+CRUDE: Average # of AUX (AOs) per Occ (Trafo)     ...   151.0
+
+--------------------------------
+LOCAL RI TRANSFORMATION (IAVPAO)
+--------------------------------
+
+Orbital window:       1 to 4
+Number of PAOs:      25
+Basis functions:     24 (12 shells)
+Aux. functions:     151 (61 shells)
+Use SHARK:           on
+
+Processing maps (0.0 sec)
+Average map sizes:
+   Aux shells -> MOs               4.0
+   Aux shells -> PAOs             25.0
+   MOs        -> AO shells        12.0
+   PAOs       -> AO shells        12.0
+
+Calculating integrals (0.1 sec, 0.117 MB)
+Sorting integrals (0.0 sec, 0.115 MB)
+Total time for the integral transformation: 0.1 sec
+
+-----------------------------------------
+   _  _______   __    ___  _  ______     
+  / |/ / __/ | / /___/ _ \/ |/ / __ \  
+ /    / _/ | |/ /___/ ___/    / /_/ /    
+/_/|_/___/ |___/   /_/  /_/|_/\____/    
+                                         
+                for open-shell molecules 
+-----------------------------------------
+
+
+ ==> UMP guess in NEV-PNO space 
+
+Truncation parameters                       .... 
+    PAOOverlapThresh     =        1.000e-08
+Pair selection                          .... not used
+    TCutPairs            =        1.000e-04
+    TCutMKN              =        1.000e-02
+    TCutDO               =        1.000e-02
+    TCutCMO              =        1.000e-03
+    TCutCPAO             =        1.000e-03
+    TCutPNO              =        3.330e-07
+    TScaleTCutPNO_SS     =        1.000e+00
+    TScaleTCutPNO_SD     =        1.000e+00
+    TScalePNO_Core       =        1.000e-02
+    TCutDO_Crude         =        2.000e-02
+    TCutMKN_Crude        =        1.000e-02
+    TCutPairs_Crude      =        1.000e-04
+    TCutPNO_Crude        =        3.330e-07
+    TCutCMO              =        1.000e-03
+    TCutCPAO             =        1.000e-03
+Spin component scaling in ijab excitation            .... not used
+
+Formation of guess energy and open-shell PNO.
+
+NEV-PNO operators..
+  E(ij->ab)
+  E(ip->ab)
+  E(pq->ra)
+  E(ip->qr)
+  E(ip->aq) and E(ip->qa)
+
+ Norm of Semi-Internal Fock Operators ...   0.0000431357
+  ==> Semi-internal excitations detected 
+
+   .... Finished loop over pairs
+
+                       ===========================
+                         13 OF   13 PAIRS ARE KEPT CC PAIRS
+                          0 OF   13 PAIRS ARE KEPT PT2 PAIRS
+                          0 OF   13 PAIRS ARE SKIPPED
+                       ===========================
+
+ Initial PAO correlation energy (all pairs)    ...  -0.1536448187 Eh
+ Energy constituents in PAO basis (Eh):
+  | Vijab(+0) ...  -0.1017901410
+  | Viab (-1) ...  -0.0331320632
+  | Va   (-1) ...  -0.0000114749
+  | Vija (+1) ...  -0.0080479739
+  | Via  (+0) ...  -0.0106631656
+  | Vi   (+1) ...  -0.0000000000
+ Initial PNO correlation energy                ...  -0.1523387622 Eh
+ Energy constituents in PNO basis (Eh):
+  | Vijab(+0) ...  -0.1017815298 (err=  0.0000086113)
+  | Viab (-1) ...  -0.0318334626 (err=  0.0012986006)
+  | Va   (-1) ...  -0.0000114749 (err=  0.0000000000)
+  | Vija (+1) ...  -0.0080491293 (err= -0.0000011554)
+  | Via  (+0) ...  -0.0106631656 (err=  0.0000000000)
+  | Vi   (+1) ...  -0.0000000000 (err=  0.0000000000)
+ Sum of total truncation errors ...   0.0013060565 Eh
+  | Pair screening ...   0.0000000000 Eh
+  | PNO truncation ...   0.0013060565 Eh
+
+ UMP2 correlation energy (PAO) ...  -0.1489222226
+  | alpha-alpha ...  -0.0230370536 (NP_aa=    6)
+  | alpha-beta  ...  -0.1149789418 (NP_ab=   12)
+  | beta -beta  ...  -0.0109062271 (NP_bb=    3)
+ UMP2 correlation energy (PNO) ...  -0.1474150452
+  | alpha-alpha ...  -0.0221647396 (err=  0.0008723140, NP_aa=    6)
+  | alpha-beta  ...  -0.1143452254 (err=  0.0006337165, NP_ab=   12)
+  | beta -beta  ...  -0.0109050802 (err=  0.0000011469, NP_bb=    3)
+ Sum of total UMP2 truncation errors ...   0.0015071774 Eh
+  | Pair screening ...   0.0000000000 Eh
+  | PNO truncation ...   0.0015071774 Eh
+ Timing for NEV-PNO construction (sec.)
+  | Intermediate construction  ..            0.000
+  | Amplitude construction     ..            0.000
+  | Total time                 ..            0.000
+ Making pair pair interaction lists ...      ok
+                                                 
+  ___         ___     __        ___  __   __     
+ |__  | |\ | |__     / _` |  | |__  /__` /__`   
+ |    | | \| |___    \__> \__/ |___ .__/ .__/ 
+                                                 
+
+Thresholds for map construction and integral transformation:
+   TCutMKN   ...     1.0e-03
+   TCutDO    ...     1.0e-02
+   TCutCMO   ...     1.0e-03
+   TCutCPAO  ...     1.0e-03
+
+--------------------------------
+LOCAL RI TRANSFORMATION (IAVPAO)
+--------------------------------
+
+Orbital window:       1 to 4
+Number of PAOs:      25
+Basis functions:     24 (12 shells)
+Aux. functions:     151 (61 shells)
+Use SHARK:           on
+
+Processing maps (0.0 sec)
+Average map sizes:
+   Aux shells -> MOs               4.0
+   Aux shells -> PAOs             25.0
+   MOs        -> AO shells        12.0
+   PAOs       -> AO shells        12.0
+
+Calculating integrals (0.1 sec, 0.117 MB)
+Sorting integrals (0.0 sec, 0.115 MB)
+Total time for the integral transformation: 0.1 sec
+
+ ==> UMP guess in NEV-PNO space 
+
+Truncation parameters                       .... 
+    PAOOverlapThresh     =        1.000e-08
+Pair selection                          .... not used
+    TCutPairs            =        1.000e-04
+    TCutMKN              =        1.000e-03
+    TCutDO               =        1.000e-02
+    TCutCMO              =        1.000e-03
+    TCutCPAO             =        1.000e-03
+    TCutPNO              =        3.330e-07
+    TScaleTCutPNO_SS     =        1.000e+00
+    TScaleTCutPNO_SD     =        1.000e+00
+    TScalePNO_Core       =        1.000e-02
+    TScaleTCutPairs_Somo =        3.300e-01
+    TScaleTCutPairs_Core =        1.000e+00
+    TCutPairs_MP2        =        1.000e-05
+    TCutCMO              =        1.000e-03
+    TCutCPAO             =        1.000e-03
+Spin component scaling in ijab excitation            .... not used
+
+Formation of guess energy and open-shell PNO.
+
+NEV-PNO operators..
+  E(ij->ab)
+  E(ip->ab)
+  E(pq->ra)
+  E(ip->qr)
+  E(ip->aq) and E(ip->qa)
+
+   .... Finished loop over pairs
+
+ PNO Occupation Number Statistics: 
+  | Av. % of trace(Dij) retained        ...  99.995558700546
+  | Av. % of trace(Dip) retained        ...  99.999999995374
+  | Av. % of trace(Dpq) retained        ... 100.000000000000
+  | sigma^2 in % of trace(Dij) retained ...   1.34e-06
+  | sigma^2 in % of trace(Dip) retained ...   2.53e-17
+  | sigma^2 in % of trace(Dpq) retained ...   0.00e+00
+  | Av. % of trace(Di) retained         ...  99.999951590335
+  | Av. % of trace(Dp) retained         ... 100.000000000000
+  | sigma^2 in % of trace(Di) retained  ...   1.17e-09
+  | sigma^2 in % of trace(Dp) retained  ...   0.00e+00
+ Distributions of % trace(Dij) recovered:
+  |       >= 99.9  ...     6 (100.0 % of all IJ-pairs)
+ Distributions of % trace(Dip) recovered:
+  |       >= 99.9  ...     3 (100.0 % of all IP-pairs)
+ Distributions of % trace(Dpq) recovered:
+  |       >= 99.9  ...     1 (100.0 % of all PQ-pairs)
+ Distributions of % trace(Di) recovered :
+  |       >= 99.9  ...     3 (100.0 % of all I-pairs )
+ Distributions of % trace(Dp) recovered :
+  |       >= 99.9  ...     1 (100.0 % of all P-pairs )
+
+                       ===========================
+                         13 OF   13 PAIRS ARE KEPT
+                       ===========================
+
+ Initial PAO correlation energy (all pairs)    ...  -0.1536440714 Eh
+ Energy constituents in PAO basis (Eh):
+  | Vijab(+0) ...  -0.1018162846
+  | Viab (-1) ...  -0.0331035990
+  | Va   (-1) ...  -0.0000114749
+  | Vija (+1) ...  -0.0080470453
+  | Via  (+0) ...  -0.0106656676
+  | Vi   (+1) ...  -0.0000000000
+ Initial PNO correlation energy                ...  -0.1523478284 Eh
+ Energy constituents in PNO basis (Eh):
+  | Vijab(+0) ...  -0.1018072916 (err=  0.0000089930)
+  | Viab (-1) ...  -0.0318151936 (err=  0.0012884054)
+  | Va   (-1) ...  -0.0000114749 (err=  0.0000000000)
+  | Vija (+1) ...  -0.0080482008 (err= -0.0000011554)
+  | Via  (+0) ...  -0.0106656676 (err=  0.0000000000)
+  | Vi   (+1) ...  -0.0000000000 (err=  0.0000000000)
+ Sum of total truncation errors ...   0.0012962430 Eh
+  | Pair screening ...   0.0000000000 Eh
+  | PNO truncation ...   0.0012962430 Eh
+
+ UMP2 correlation energy (PAO) ...  -0.1489203695
+  | alpha-alpha ...  -0.0230084937 (NP_aa=    6)
+  | alpha-beta  ...  -0.1150126917 (NP_ab=   12)
+  | beta -beta  ...  -0.0108991842 (NP_bb=    3)
+ UMP2 correlation energy (PNO) ...  -0.1474290597
+  | alpha-alpha ...  -0.0221431608 (err=  0.0008653328, NP_aa=    6)
+  | alpha-beta  ...  -0.1143876679 (err=  0.0006250237, NP_ab=   12)
+  | beta -beta  ...  -0.0108982309 (err=  0.0000009532, NP_bb=    3)
+ Sum of total UMP2 truncation errors ...   0.0014913098 Eh
+  | Pair screening ...   0.0000000000 Eh
+  | PNO truncation ...   0.0014913098 Eh
+ Timing for NEV-PNO construction (sec.)
+  | Intermediate construction  ..            0.000
+  | Amplitude construction     ..            0.000
+  | Total time                 ..            0.000
+ Making pair pair interaction lists ...      ok
+ Total size for 2-ext PNO integrals ...      0.0 MB
+Checking the number of SOMO/SOMO doubles PNOs ...  No PNOs should be truncated!
+
+--------------------------------
+LOCAL RI TRANSFORMATION (VABPAO)
+--------------------------------
+
+Number of PAOs:      25
+Basis functions:     24 (12 shells)
+Aux. functions:     151 (61 shells)
+Use SHARK:           on
+
+Processing maps (0.0 sec)
+Average map sizes:
+   Aux shells -> PAOs             25.0
+   PAOs       -> AO shells        12.0
+
+Calculating integrals (0.1 sec, 0.722 MB)
+Finished
+-----------------------------
+LOCAL RI TRANSFORMATION (IJV)
+-----------------------------
+
+Orbital window:       1 to 4
+Basis functions:     24 (12 shells)
+Aux. functions:     151 (61 shells)
+Use SHARK:           on
+
+Processing maps (0.0 sec)
+Average map sizes:
+   Aux shells -> MOs(i)            4.0
+   Aux shells -> MOs(j)            4.0
+   MOs        -> AO shells        12.0
+
+Calculating integrals (0.1 sec, 0.020 MB)
+Sorting integrals (0.0 sec, 0.018 MB)
+Total time for the integral transformation: 0.1 sec
+
+
+-------------------------------------
+Pair Pair Term precalculation with     
+RI-(ij|mn) and (im|jn) transformation  
+ON THE FLY                             
+-------------------------------------
+
+   IBatch   1 (of   1)              ... done (    0.023 sec)
+Total EXT                           ...           0.023 sec
+
+---------------------
+RI-PNO TRANSFORMATION
+---------------------
+
+Total Number of PNOs                   ...   221
+Total Number of IJ-PNOs                ...   165
+Total Number of IP-PNOs                ...    36
+Total Number of PQ-PNOs                ...    20
+Total Number of IJ-pairs               ...     9
+Total Number of PI-pairs               ...     3
+Total Number of PQ-pairs               ...     1
+Average number of PNOs per pair        ...    17
+Maximal number of PNOs per pair        ...    20
+>> Statistics for ij-pairs..
+   #pairs with  1 -  5 PNOs   :    0
+   #pairs with  6 - 10 PNOs   :    0
+   #pairs with 11 - 15 PNOs   :    0
+   #pairs with 16 - 20 PNOs   :    9
+   #pairs with 21 - 25 PNOs   :    0
+   #pairs with 26 - 30 PNOs   :    0
+   #pairs with 31 - 35 PNOs   :    0
+   #pairs with 36 - 40 PNOs   :    0
+   #pairs with 41 - 45 PNOs   :    0
+   #pairs with 46 - 50 PNOs   :    0
+>> Statistics for ip-pairs..
+   #pairs with  1 -  5 PNOs   :    0
+   #pairs with  6 - 10 PNOs   :    0
+   #pairs with 11 - 15 PNOs   :    3
+   #pairs with 16 - 20 PNOs   :    0
+   #pairs with 21 - 25 PNOs   :    0
+   #pairs with 26 - 30 PNOs   :    0
+   #pairs with 31 - 35 PNOs   :    0
+   #pairs with 36 - 40 PNOs   :    0
+   #pairs with 41 - 45 PNOs   :    0
+   #pairs with 46 - 50 PNOs   :    0
+>> Statistics for pq-pairs..
+   #pairs with  1 -  5 PNOs   :    0
+   #pairs with  6 - 10 PNOs   :    0
+   #pairs with 11 - 15 PNOs   :    0
+   #pairs with 16 - 20 PNOs   :    1
+   #pairs with 21 - 25 PNOs   :    0
+   #pairs with 26 - 30 PNOs   :    0
+   #pairs with 31 - 35 PNOs   :    0
+   #pairs with 36 - 40 PNOs   :    0
+   #pairs with 41 - 45 PNOs   :    0
+   #pairs with 46 - 50 PNOs   :    0
+
+Generation of (ij|ab)[P] integrals            ... on
+Generation of (ia|bc)[P],(ja|bc)[P] integrals ... on
+Storage of 3 and 4 external integrals         ... on
+Generation of ALL (ka|bc)[P] integrals        ... on
+Keep RI integrals in memory                   ... off
+
+Ibatch:  1 (of  1)
+Starting 2-4 index PNO integral generation ... done
+
+Timings:
+Total PNO integral transformation time     ...          0.024 sec
+Size of the 3-external file                ...         0 MB
+Size of the 4-external file                ...         0 MB
+Size of the IKJL file                      ...         0 MB
+Size of the all 3-external file            ...         0 MB
+Size of the 1-external file                ...         0 MB
+
+Size of the PAO/PNO coefficient matrices   ...       0.0 MB
+
+Average # of AOs per PAO                   ...    24.0
+Average # of atoms per PAO                 ...     3.0
+Average # of atoms per a pair domain       ...    3.00
+Average # of atoms per AUX domain          ...    2.50
+Average # of atoms per a pair AUX domain   ...    2.85
+
+ * Extended Maps .. 
+Average # of PAOs (Atoms) per Occ          ...     3.0
+Average # of PAOs (AOs) per Occ            ...    25.0
+
+ * Trafo Maps .. 
+Average # of PAOs (Atoms) per Occ (Trafo)  ...     3.0
+Average # of PAOs (AOs) per Occ (Trafo)    ...    25.0
+Average # of AUX (Atoms) per Occ (Trafo)   ...     3.0
+Average # of AUX (AOs) per Occ (Trafo)     ...   151.0
+
+Making pair/pair overlap matrices          ... done (    0.002 sec)
+Size of the pair overlap file              ...       0.0 MB
+Total # unrestricted pairs ...         21
+  # of alpha-alpha pairs   ...          6
+  # of alpha-beta pairs    ...         12
+  # of beta-beta pairs     ...          3
+Constructing the guess amplitudes          ... done (    0.001 sec)
+
+-------------------------
+FINAL STARTUP INFORMATION
+-------------------------
+
+E(0)                                       ...    -75.558526732
+E(SL-UMP2 in NEV-PNO space)                ...     -0.148920369
+Initial E(tot)                             ...    -75.707447101
+<T|T>                                      ...      0.027549905
+Number of unrestricted pairs included      ... 21
+Total number of pairs                      ... 21
+----------------------------------------------------------
+                     OPEN-SHELL COUPLED CLUSTER ITERATIONS
+----------------------------------------------------------
+
+Number of PNO amplitudes to be optimized        ...             5814
+Number of canonical amplitudes for strong pairs ...             8062
+Untruncated number of canonical amplitudes      ...             8062
+
+Iter       E(tot)           E(Corr)          Delta-E          Residual     Time
+  0    -75.711340574     -0.151322532     -0.002402163      0.018550220    0.05
+                           *** Turning on DIIS ***
+  1    -75.725201595     -0.165183553     -0.013861021      0.007659120    0.04
+  2    -75.730126091     -0.170108049     -0.004924496      0.002088743    0.05
+  3    -75.730908364     -0.170890323     -0.000782274      0.000902866    0.04
+  4    -75.731085305     -0.171067263     -0.000176941      0.000425806    0.04
+  5    -75.731109180     -0.171091138     -0.000023875      0.000188264    0.08
+  6    -75.731113734     -0.171095693     -0.000004555      0.000073073    0.11
+  7    -75.731114338     -0.171096297     -0.000000604      0.000021311    0.08
+               --- The CCSD iterations have converged ---
+
+E(0)                                       ...    -75.558526732
+E(CORR)(strong-pairs)                      ...     -0.171096297
+E(CORR)(weak-pairs)                        ...     -0.001491310
+E(CORR)(corrected)                         ...     -0.172587606
+E(TOT)                                     ...    -75.731114338
+Singles norm <S|S>**1/2                    ...      0.032186843 ( 0.017002203, 0.015184640)  
+T1 diagnostic                              ...      0.012165483                              
+<S**2>(linearized)                         ...      0.7501480 (ideal value:      0.7500000)
+
+----------------------
+LARGEST PNO AMPLITUDES
+----------------------
+   1a->  8a   1b->  8b       0.038705
+   3a->  7a   3b->  7b       0.035642
+   2a->  7a   2b->  7b       0.035642
+   3a->  5a   3b->  5b       0.031907
+   2a->  5a   2b->  5b       0.031907
+   4a->  7a   1b->  8b       0.030896
+   4a-> 11a   1b->  4b       0.026215
+   3a->  5a   3b->  7b       0.025891
+   2a->  5a   2b->  7b       0.025891
+   3a->  7a   3b->  5b       0.025463
+   2a->  7a   2b->  5b       0.025463
+   4a->  7a   2b->  5b       0.025391
+   4a->  7a   3b->  5b       0.025382
+   1a->  6a   1b->  6b       0.022173
+   4a->  5a   2b->  4b       0.021790
+   4a->  5a   3b->  4b       0.021786
+
+----------------------------
+STATISTICS FOR PAIR-ENERGIES
+----------------------------
+Minimum, maximum and average ratios of UMP and CCSD pair-energies ... 0.93, 1.22, 1.07
+
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
+        !  Warning: Linearized densities requested! These are not the proper     !
+        !  density matrices for non-variational theories, e.g., CCSD, QCISD.     !
+        !  It is better to use the Density = Unrelaxed option in the input.      !
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
+
+NORM  =      1.047309258 sqrt=     1.023381287
+W(HF) =      0.954827805
+------------------------------------------------------------------------------
+                           ORCA POPULATION ANALYSIS
+------------------------------------------------------------------------------
+Input electron density              ... water_spe_CCSD.mdcip
+Input spin density                  ... water_spe_CCSD.mdcir
+BaseName (.gbw .S,...)              ... water_spe_CCSD
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+------------------------------------------
+MULLIKEN ATOMIC CHARGES AND SPIN DENSITIES
+------------------------------------------
+   0 O :    0.391458    1.061085
+   1 H :    0.304269   -0.030540
+   2 H :    0.304274   -0.030544
+Sum of atomic charges       :    1.0000000
+Sum of atomic spin densities:    1.0000000
+
+---------------------------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES AND SPIN DENSITIES
+---------------------------------------------------
+CHARGE
+  0 O s       :     3.712405  s :     3.712405
+      pz      :     1.230535  p :     3.867258
+      px      :     1.394026
+      py      :     1.242698
+      dz2     :     0.005176  d :     0.028879
+      dxz     :     0.004284
+      dyz     :     0.007158
+      dx2y2   :     0.007943
+      dxy     :     0.004318
+  1 H s       :     0.622791  s :     0.622791
+      pz      :     0.012192  p :     0.072941
+      px      :     0.048358
+      py      :     0.012391
+  2 H s       :     0.622785  s :     0.622785
+      pz      :     0.025662  p :     0.072941
+      px      :     0.020751
+      py      :     0.026528
+
+SPIN
+  0 O s       :     0.036949  s :     0.036949
+      pz      :     0.508364  p :     1.019811
+      px      :     0.026108
+      py      :     0.485339
+      dz2     :     0.001421  d :     0.004325
+      dxz     :     0.000809
+      dyz     :     0.000834
+      dx2y2   :     0.000492
+      dxy     :     0.000769
+  1 H s       :    -0.036820  s :    -0.036820
+      pz      :     0.003494  p :     0.006279
+      px      :    -0.000516
+      py      :     0.003301
+  2 H s       :    -0.036823  s :    -0.036823
+      pz      :     0.003546  p :     0.006279
+      px      :    -0.000624
+      py      :     0.003356
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+-----------------------------------------
+LOEWDIN ATOMIC CHARGES AND SPIN DENSITIES
+-----------------------------------------
+   0 O :    0.608083    0.998156
+   1 H :    0.195956    0.000923
+   2 H :    0.195961    0.000921
+
+--------------------------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES AND SPIN DENSITIES
+--------------------------------------------------
+CHARGE
+  0 O s       :     3.453788  s :     3.453788
+      pz      :     1.232610  p :     3.900763
+      px      :     1.421868
+      py      :     1.246285
+      dz2     :     0.006295  d :     0.037366
+      dxz     :     0.004372
+      dyz     :     0.010176
+      dx2y2   :     0.012103
+      dxy     :     0.004421
+  1 H s       :     0.636067  s :     0.636067
+      pz      :     0.027991  p :     0.167977
+      px      :     0.111733
+      py      :     0.028254
+  2 H s       :     0.636064  s :     0.636064
+      pz      :     0.064472  p :     0.167975
+      px      :     0.036966
+      py      :     0.066538
+
+SPIN
+  0 O s       :     0.022020  s :     0.022020
+      pz      :     0.489495  p :     0.972295
+      px      :     0.015859
+      py      :     0.466941
+      dz2     :     0.001133  d :     0.003841
+      dxz     :     0.000664
+      dyz     :     0.001217
+      dx2y2   :     0.000201
+      dxy     :     0.000625
+  1 H s       :    -0.024545  s :    -0.024545
+      pz      :     0.010975  p :     0.025468
+      px      :     0.004056
+      py      :     0.010437
+  2 H s       :    -0.024547  s :    -0.024547
+      pz      :     0.012869  p :     0.025468
+      px      :     0.000173
+      py      :     0.012426
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 O      7.6085     8.0000     0.3915     2.9594     1.7481     1.2113
+  1 H      0.6957     1.0000     0.3043     0.9338     0.8861     0.0478
+  2 H      0.6957     1.0000     0.3043     0.9338     0.8861     0.0478
+
+  Mayer bond orders larger than 0.100000
+B(  0-O ,  1-H ) :   0.8740 B(  0-O ,  2-H ) :   0.8740 
+
+
+
+--------------------------------------------------------------------------------
+                                    TIMINGS
+--------------------------------------------------------------------------------
+
+
+Total execution time                   ...        2.218 sec
+
+Localization of occupied MO's          ...        0.411 sec ( 18.5%)
+Fock Matrix Formation                  ...        0.251 sec ( 11.3%)
+Differential overlap integrals         ...        0.048 sec (  2.2%)
+Organizing maps                        ...        0.001 sec (  0.0%)
+RI 3-index integral generations        ...        0.380 sec ( 17.2%)
+RI-PNO integral transformation         ...        0.061 sec (  2.7%)
+Initial Guess                          ...        0.086 sec (  3.9%)
+DIIS Solver                            ...        0.023 sec (  1.0%)
+State Vector Update                    ...        0.001 sec (  0.0%)
+Sigma-vector construction              ...        0.497 sec ( 22.4%)
+  <D|H|D>(0-ext)                       ...        0.019 sec (  3.7% of sigma)
+  <D|H|D>(2-ext Fock)                  ...        0.002 sec (  0.4% of sigma)
+  <D|H|D>(2-ext)                       ...        0.069 sec ( 13.9% of sigma)
+  <D|H|D>(4-ext)                       ...        0.040 sec (  8.0% of sigma)
+  <D|H|D>(4-ext-corr)                  ...        0.102 sec ( 20.5% of sigma)
+  CCSD doubles correction              ...        0.010 sec (  1.9% of sigma)
+  <S|H|S>                              ...        0.015 sec (  3.0% of sigma)
+  <S|H|D>(1-ext)                       ...        0.003 sec (  0.5% of sigma)
+  <S|H|D>(3-ext)                       ...        0.005 sec (  1.0% of sigma)
+  Fock-dressing                        ...        0.073 sec ( 14.6% of sigma)
+  Singles amplitudes                   ...        0.004 sec (  0.8% of sigma)
+  (ik|jl)-dressing                     ...        0.031 sec (  6.3% of sigma)
+  (ij|ab),(ia|jb)-dressing             ...        0.074 sec ( 14.9% of sigma)
+
+
+Maximum memory used throughout the entire MDCI-calculation: 86.6 MB
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -75.731114338261
+-------------------------   --------------------
+
+
+                            ***************************************
+                            *     ORCA property calculations      *
+                            ***************************************
+
+                                    ---------------------
+                                    Active property flags
+                                    ---------------------
+   (+) Dipole Moment
+
+
+------------------------------------------------------------------------------
+                       ORCA ELECTRIC PROPERTIES CALCULATION
+------------------------------------------------------------------------------
+
+Dipole Moment Calculation                       ... on
+Quadrupole Moment Calculation                   ... off
+Polarizability Calculation                      ... off
+GBWName                                         ... water_spe_CCSD.gbw
+Electron density                                ... water_spe_CCSD.scfp
+The origin for moment calculation is the CENTER OF MASS  = (-5.993827, -1.179295  0.045610)
+
+-------------
+DIPOLE MOMENT
+-------------
+                                X             Y             Z
+Electronic contribution:      0.02017      -0.02044       0.01992
+Nuclear contribution   :      0.57352      -0.58041       0.56656
+                        -----------------------------------------
+Total Dipole Moment    :      0.59369      -0.60084       0.58648
+                        -----------------------------------------
+Magnitude (a.u.)       :      1.02832
+Magnitude (Debye)      :      2.61378
+
+
+
+--------------------
+Rotational spectrum 
+--------------------
+ 
+Rotational constants in cm-1:    26.442708    14.345901     9.300255 
+Rotational constants in MHz : 792732.440810 430079.286725 278814.632727 
+
+ Dipole components along the rotational axes: 
+x,y,z [a.u.] :     0.000025     1.028321    -0.000025 
+x,y,z [Debye]:     0.000063     2.613784    -0.000063 
+
+ 
+
+                           *** MDCI DENSITY ***
+
+------------------------------------------------------------------------------
+                       ORCA ELECTRIC PROPERTIES CALCULATION
+------------------------------------------------------------------------------
+
+Dipole Moment Calculation                       ... on
+Quadrupole Moment Calculation                   ... off
+Polarizability Calculation                      ... off
+GBWName                                         ... water_spe_CCSD.gbw
+Electron density                                ... water_spe_CCSD.mdcip
+The origin for moment calculation is the CENTER OF MASS  = (-5.993827, -1.179295  0.045610)
+
+-------------
+DIPOLE MOMENT
+-------------
+                                X             Y             Z
+Electronic contribution:     -0.00274       0.00277      -0.00271
+Nuclear contribution   :      0.57352      -0.58041       0.56656
+                        -----------------------------------------
+Total Dipole Moment    :      0.57078      -0.57764       0.56386
+                        -----------------------------------------
+Magnitude (a.u.)       :      0.98863
+Magnitude (Debye)      :      2.51290
+
+
+
+--------------------
+Rotational spectrum 
+--------------------
+ 
+Rotational constants in cm-1:    26.442708    14.345901     9.300255 
+Rotational constants in MHz : 792732.440810 430079.286725 278814.632727 
+
+ Dipole components along the rotational axes: 
+x,y,z [a.u.] :     0.000019     0.988630    -0.000005 
+x,y,z [Debye]:     0.000048     2.512898    -0.000013 
+
+ 
+
+Timings for individual modules:
+
+Sum of individual times         ...        4.274 sec (=   0.071 min)
+GTO integral calculation        ...        0.639 sec (=   0.011 min)  15.0 %
+SCF iterations                  ...        1.083 sec (=   0.018 min)  25.3 %
+MDCI module                     ...        2.552 sec (=   0.043 min)  59.7 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 0 minutes 4 seconds 672 msec


### PR DESCRIPTION
Fixed the following issues:

- Edited constructor when using `inplace=False` (passed charge and spin as keyworded arguments)
- Patch to Mulliken spin population parser
- Patch to strip of extension in Fukui function renderer
- Purged forbidden characters from output suffix

Updated the integration tests accordingly

Closes #81, closes #83