### PR TITLE
Bugfix in orca e dftbplus

### DIFF
--- a/compechem/engines/dftbplus.py
+++ b/compechem/engines/dftbplus.py
@@ -1,8 +1,9 @@
 import os, copy, shutil, sh
 
+import compechem.config as cfg
+from compechem.config import get_ncores
 from os.path import join
 from tempfile import mkdtemp
-from compechem.config import get_ncores, MPI_FLAGS
 from compechem.core.base import Engine
 from compechem.systems import System, Ensemble
 from compechem.tools import (
@@ -367,7 +368,7 @@ class DFTBInput(Engine):
             if self.parallel == "mpi":
                 os.environ["OMP_NUM_THREADS"] = "1"
                 os.system(
-                    f"mpirun -np {ncores} {MPI_FLAGS} {self.__DFTBPATH} > output.out 2>> output.err"
+                    f"mpirun -np {ncores} {cfg.MPI_FLAGS} {self.__DFTBPATH} > output.out 2>> output.err"
                 )
 
             elif self.parallel == "nompi":
@@ -459,7 +460,7 @@ class DFTBInput(Engine):
             if self.parallel == "mpi":
                 os.environ["OMP_NUM_THREADS"] = "1"
                 os.system(
-                    f"mpirun -np {ncores} {MPI_FLAGS} {self.__DFTBPATH} > output.out 2>> output.err"
+                    f"mpirun -np {ncores} {cfg.MPI_FLAGS} {self.__DFTBPATH} > output.out 2>> output.err"
                 )
 
             elif self.parallel == "nompi":
@@ -577,7 +578,7 @@ class DFTBInput(Engine):
             if self.parallel == "mpi":
                 os.environ["OMP_NUM_THREADS"] = "1"
                 os.system(
-                    f"mpirun -np {ncores} {MPI_FLAGS} {self.__DFTBPATH} > {self.output_path} 2>> output.err"
+                    f"mpirun -np {ncores} {cfg.MPI_FLAGS} {self.__DFTBPATH} > {self.output_path} 2>> output.err"
                 )
             elif self.parallel == "nompi":
                 os.environ["OMP_NUM_THREADS"] = f"{ncores}"
@@ -717,7 +718,7 @@ class DFTBInput(Engine):
             if self.parallel == "mpi":
                 os.environ["OMP_NUM_THREADS"] = "1"
                 os.system(
-                    f"mpirun -np {ncores} {MPI_FLAGS} {self.__DFTBPATH} > {self.output_path} 2>> output.err"
+                    f"mpirun -np {ncores} {cfg.MPI_FLAGS} {self.__DFTBPATH} > {self.output_path} 2>> output.err"
                 )
             elif self.parallel == "nompi":
                 os.environ["OMP_NUM_THREADS"] = f"{ncores}"

--- a/compechem/engines/orca.py
+++ b/compechem/engines/orca.py
@@ -1,15 +1,15 @@
-import os, copy, shutil, sh
+import os, copy, shutil, sh, logging
 from typing import Dict
 from tempfile import mkdtemp
 
-from compechem.config import get_ncores, MPI_FLAGS
+import compechem.config as cfg
+from compechem.config import get_ncores
 from compechem.systems import Ensemble, System
 from compechem.tools import process_output
 from compechem.core.base import Engine
 from compechem.core.dependency_finder import locate_orca
 from compechem.tools.internaltools import clean_suffix
 
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -221,7 +221,7 @@ class OrcaInput(Engine):
                 },
             )
 
-            os.system(f"{self.__ORCADIR}/orca input.inp > output.out '{MPI_FLAGS}'")
+            os.system(f"{self.__ORCADIR}/orca input.inp > output.out '{cfg.MPI_FLAGS}'")
 
             if inplace is False:
                 newmol = System(f"{mol.name}.xyz", charge=charge, spin=spin)
@@ -320,7 +320,7 @@ class OrcaInput(Engine):
                 },
             )
 
-            os.system(f"{self.__ORCADIR}/orca input.inp > output.out '{MPI_FLAGS}'")
+            os.system(f"{self.__ORCADIR}/orca input.inp > output.out '{cfg.MPI_FLAGS}'")
 
             if inplace is False:
                 newmol = System("input.xyz", charge, spin)
@@ -415,7 +415,7 @@ class OrcaInput(Engine):
                 },
             )
 
-            os.system(f"{self.__ORCADIR}/orca input.inp > output.out '{MPI_FLAGS}'")
+            os.system(f"{self.__ORCADIR}/orca input.inp > output.out '{cfg.MPI_FLAGS}'")
 
             if inplace is False:
                 newmol = System(f"{mol.name}.xyz", charge=charge, spin=spin)
@@ -501,7 +501,7 @@ class OrcaInput(Engine):
                 },
             )
 
-            os.system(f"{self.__ORCADIR}/orca input.inp > output.out '{MPI_FLAGS}'")
+            os.system(f"{self.__ORCADIR}/orca input.inp > output.out '{cfg.MPI_FLAGS}'")
 
             if inplace is False:
                 newmol = System(f"{mol.name}.xyz", charge=charge, spin=spin)
@@ -595,7 +595,7 @@ class OrcaInput(Engine):
                 },
             )
 
-            os.system(f"{self.__ORCADIR}/orca input.inp > output.out '{MPI_FLAGS}'")
+            os.system(f"{self.__ORCADIR}/orca input.inp > output.out '{cfg.MPI_FLAGS}'")
 
             xyz_list = [
                 xyz


### PR DESCRIPTION
Added the correct syntax to access the global variable `MPI_FLAGS` inside the engines definitions.

Closes #93 