### PR TITLE
Bugfix in __check_engine function in Properties class

### DIFF
--- a/compechem/core/properties.py
+++ b/compechem/core/properties.py
@@ -136,6 +136,8 @@ class Properties:
 
     def __check_engine(self, engine: Union(Engine, str)) -> None:
 
+        logger.debug(f"Engine type: {type(engine)}")
+
         if type(engine) == str:
             if not any(
                 [
@@ -147,19 +149,23 @@ class Properties:
                 raise TypeError(
                     "The engine argument string does not match any valid level of theory"
                 )
-
-        elif not isinstance(engine, Engine):
-            raise TypeError("The engine argument must be derived from `Engine`")
-
-        else:
-            if isinstance(engine, Engine):
-                return engine.level_of_theory
             else:
                 return engine
+
+        elif isinstance(engine, Engine):
+            return engine.level_of_theory
+
+        else:
+            raise TypeError("The engine argument must be derived from `Engine`")
 
     def __validate_electronic(self, engine: Union(Engine, str)) -> None:
 
         level_of_theory = self.__check_engine(engine)
+
+        logger.debug("Validating electronic energy")
+        logger.debug(
+            f"current: {self.__level_of_theory_electronic}, requested: {level_of_theory}"
+        )
 
         if self.__level_of_theory_electronic is None:
             self.__level_of_theory_electronic = level_of_theory
@@ -180,6 +186,11 @@ class Properties:
     def __validate_vibronic(self, engine: Engine) -> None:
 
         level_of_theory = self.__check_engine(engine)
+
+        logger.debug("Validating vibronic energy")
+        logger.debug(
+            f"current: {self.__level_of_theory_vibronic}, requested: {level_of_theory}"
+        )
 
         if self.__level_of_theory_vibronic is None:
             self.__level_of_theory_vibronic = level_of_theory
@@ -314,6 +325,7 @@ class Properties:
         electronic_engine: Union(Engine, str)
             The engine used in the calculation.
         """
+        logger.debug("Setting electronic energy")
         self.__validate_electronic(electronic_engine)
         self.__electronic_energy = value
 
@@ -342,6 +354,7 @@ class Properties:
         vibronic_engine: Union(Engine, str)
             The engine used in the calculation.
         """
+        logger.debug("Setting vibronic energy")
         self.__validate_vibronic(vibronic_engine)
         self.__vibronic_energy = value
 
@@ -375,6 +388,7 @@ class Properties:
         vibronic_engine: Union(Engine, str)
             The engine used in the vibronic calculation.
         """
+        logger.debug("Setting Helmholtz free energy")
         self.__validate_electronic(electronic_engine)
         self.__validate_vibronic(vibronic_engine)
         self.__helmholtz_free_energy = value
@@ -409,6 +423,7 @@ class Properties:
         vibronic_engine: Union(Engine, str)
             The engine used in the vibronic calculation.
         """
+        logger.debug("setting Gibbs free energy")
         self.__validate_electronic(electronic_engine)
         self.__validate_vibronic(vibronic_engine)
         self.__gibbs_free_energy = value
@@ -443,6 +458,7 @@ class Properties:
         vibronic_engine: Union(Engine, str)
             The engine used in the vibronic calculation. (optional)
         """
+        logger.debug("Setting pKa")
         self.__validate_electronic(electronic_engine)
         if vibronic_engine is not None:
             self.__validate_vibronic(vibronic_engine)
@@ -473,6 +489,7 @@ class Properties:
         electronic_engine: Union(Engine, str)
             The engine used in the electronic calculation.
         """
+        logger.debug("Setting Mulliken charges")
         self.__validate_electronic(electronic_engine)
         self.__mulliken_charges = value
 
@@ -501,6 +518,7 @@ class Properties:
         electronic_engine: Union(Engine, str)
             The engine used in the electronic calculation.
         """
+        logger.debug("Setting Mulliken Spin populations")
         self.__validate_electronic(electronic_engine)
         self.__mulliken_spin_populations = value
 
@@ -533,6 +551,7 @@ class Properties:
         electronic_engine: Union(Engine, str)
             The engine used in the electronic calculation.
         """
+        logger.debug("Setting condensed Fukui functions (Mulliken)")
         self.__validate_electronic(electronic_engine)
         self.__condensed_fukui_mulliken = value
 
@@ -561,6 +580,7 @@ class Properties:
         electronic_engine: Union(Engine, str)
             The engine used in the electronic calculation.
         """
+        logger.debug("Setting Hirshfeld charges")
         self.__validate_electronic(electronic_engine)
         self.__hirshfeld_charges = value
 
@@ -589,6 +609,7 @@ class Properties:
         electronic_engine: Union(Engine, str)
             The engine used in the electronic calculation.
         """
+        logger.debug("Setting Hirshfeld Spin populations")
         self.__validate_electronic(electronic_engine)
         self.__hirshfeld_spin_populations = value
 
@@ -621,5 +642,6 @@ class Properties:
         electronic_engine: Union(Engine, str)
             The engine used in the electronic calculation.
         """
+        logger.debug("Setting condensed Fukui functions (Hirshfeld)")
         self.__validate_electronic(electronic_engine)
         self.__condensed_fukui_hirshfeld = value

--- a/compechem/functions/pka.py
+++ b/compechem/functions/pka.py
@@ -98,9 +98,9 @@ def calculate_pka(protonated: System, deprotonated: System):
     ) / (2.303 * 1.98720425864083 / 1000 * 298.15)
 
     protonated.properties.set_pka(
-        pka,
-        protonated.properties.level_of_theory_electronic,
-        protonated.properties.level_of_theory_vibronic,
+        value=pka,
+        electronic_engine=protonated.properties.level_of_theory_electronic,
+        vibronic_engine=protonated.properties.level_of_theory_vibronic,
     )
 
     return pka

--- a/compechem/functions/potential.py
+++ b/compechem/functions/potential.py
@@ -1,6 +1,7 @@
 from compechem.systems import Ensemble
 from compechem.systems import System
 from compechem.constants import Eh_to_kcalmol
+from typing import Tuple
 
 import logging
 
@@ -11,7 +12,7 @@ def calculate_reduction_potential(
     oxidised: System,
     reduced: System,
     pH: float = 7.0,
-):
+) -> Tuple[float, int, int]:
     """
     Calculates the reduction potential of a molecule, given the oxidized and reduced forms
     assuming that energies have already been computed. The number of electrons exchanged in

--- a/compechem/functions/potential.py
+++ b/compechem/functions/potential.py
@@ -57,10 +57,13 @@ def calculate_reduction_potential(
     reduced_protons = reduced.geometry.atoms.count("H")
     exchanged_protons = reduced_protons - oxidised_protons
 
+    exchanged_electrons = (oxidised.charge - reduced.charge) + exchanged_protons
     if exchanged_protons != 0:
         logger.info(
-            f"PCET mechanism detected, {exchanged_protons} protons exchanged. Calculated potential will be pH-dependent."
+            f"{exchanged_electrons}e/{exchanged_protons}H PCET reduction detected. Calculated potential is pH-dependent."
         )
+    else:
+        logger.info(f"{exchanged_electrons}e reduction detected.")
 
     if reduced.geometry.atomcount - oxidised.geometry.atomcount != exchanged_protons:
         logger.error(
@@ -69,9 +72,6 @@ def calculate_reduction_potential(
         raise RuntimeError(
             "oxidised and reduced forms are not the same molecule. Only molecules differing for the number of protons are allowed."
         )
-
-    exchanged_electrons = (oxidised.charge - reduced.charge) + exchanged_protons
-    logger.info(f"{exchanged_electrons}-electron reduction detected.")
 
     if exchanged_electrons < 0:
         logger.error(

--- a/compechem/functions/potential.py
+++ b/compechem/functions/potential.py
@@ -60,10 +60,10 @@ def calculate_reduction_potential(
     exchanged_electrons = (oxidised.charge - reduced.charge) + exchanged_protons
     if exchanged_protons != 0:
         logger.info(
-            f"{exchanged_electrons}e/{exchanged_protons}H PCET reduction detected. Calculated potential is pH-dependent."
+            f"pH = {pH}: {exchanged_electrons}e/{exchanged_protons}H PCET reduction detected. Calculated potential is pH-dependent."
         )
     else:
-        logger.info(f"{exchanged_electrons}e reduction detected.")
+        logger.info(f"pH = {pH}: {exchanged_electrons}e reduction detected.")
 
     if reduced.geometry.atomcount - oxidised.geometry.atomcount != exchanged_protons:
         logger.error(

--- a/tests/unit/test_properties.py
+++ b/tests/unit/test_properties.py
@@ -201,21 +201,13 @@ def test_pka_vibronic_addition_not_strict():
 def test_check_engine():
 
     p = Properties()
-    engine = XtbInput()
 
     try:
-        p.set_electronic_energy(0.1, engine)
-    except:
-        assert False, "Exception raised when Engine is passed to check_engine"
-
-    assert p.level_of_theory_electronic == engine.level_of_theory
-
-    try:
-        p.set_electronic_energy(0.1, engine.level_of_theory)
+        p.set_electronic_energy(0.1, "XtbInput || method: gfn2 | solvent: None")
     except:
         assert False, "Exception raised when string is passed to check_engine"
 
-    assert p.level_of_theory_electronic == engine.level_of_theory
+    assert p.level_of_theory_electronic == "XtbInput || method: gfn2 | solvent: None"
 
     try:
         p.set_electronic_energy(0.1, "This is a string")

--- a/tests/unit/test_properties.py
+++ b/tests/unit/test_properties.py
@@ -4,6 +4,7 @@ from numpy.testing import assert_array_almost_equal
 import compechem.config as cc
 from compechem.core.base import Engine
 from compechem.core.properties import Properties
+from compechem.engines.xtb import XtbInput
 
 # Test the Properties class
 # ------------------------------------------------------------------------------------------
@@ -200,6 +201,21 @@ def test_pka_vibronic_addition_not_strict():
 def test_check_engine():
 
     p = Properties()
+    engine = XtbInput()
+
+    try:
+        p.set_electronic_energy(0.1, engine)
+    except:
+        assert False, "Exception raised when Engine is passed to check_engine"
+
+    assert p.level_of_theory_electronic == engine.level_of_theory
+
+    try:
+        p.set_electronic_energy(0.1, engine.level_of_theory)
+    except:
+        assert False, "Exception raised when string is passed to check_engine"
+
+    assert p.level_of_theory_electronic == engine.level_of_theory
 
     try:
         p.set_electronic_energy(0.1, "This is a string")


### PR DESCRIPTION
Fixed bug for which the `__check_engine` function returned None if `engine` was passed as a correctly formatted string. Added extra tests to ensure this works correctly

Also, added some more info to logger at debug level for Properties